### PR TITLE
feat: add global setup/teardown and project dependency support

### DIFF
--- a/.github/workflows/playwright-compat.yml
+++ b/.github/workflows/playwright-compat.yml
@@ -77,8 +77,9 @@ jobs:
 
           | API | Used in |
           |-----|---------|
-          | \`playwright/lib/common/configLoader\` — \`loadConfig\`, \`resolveConfigLocation\` | \`packages/core/src/runner/web-server-manager.ts\` |
+          | \`playwright/lib/common/configLoader\` — \`loadConfig\`, \`resolveConfigLocation\` | \`packages/core/src/helpers/playwright-config.ts\` |
           | \`playwright/lib/plugins\` — \`webServer\` | \`packages/core/src/runner/web-server-manager.ts\` |
+          | \`playwright/lib/runner/loadUtils\` — \`loadGlobalHook\` | \`packages/core/src/runner/global-setup-manager.ts\` |
           | \`Suite._parallelMode\` | \`packages/core/src/playwright-tools/run-builder.ts\` |
 
           [View workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})

--- a/e2e/globalHooks/constants.mts
+++ b/e2e/globalHooks/constants.mts
@@ -1,0 +1,2 @@
+export const globalSetupMarkerFile = '.global-setup-marker';
+export const globalTeardownMarkerFile = '.global-teardown-marker';

--- a/e2e/globalHooks/global-setup.mts
+++ b/e2e/globalHooks/global-setup.mts
@@ -1,0 +1,12 @@
+import { readFileSync, existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { globalSetupMarkerFile } from './constants.mts';
+
+export default async function globalSetup() {
+    const reportFolder = process.env.MARKER_FOLDER;
+    if (!reportFolder) return;
+    mkdirSync(reportFolder, { recursive: true });
+    const marker = join(reportFolder, globalSetupMarkerFile);
+    const count = existsSync(marker) ? parseInt(readFileSync(marker, 'utf-8'), 10) + 1 : 1;
+    writeFileSync(marker, String(count));
+}

--- a/e2e/globalHooks/global-teardown.mts
+++ b/e2e/globalHooks/global-teardown.mts
@@ -1,0 +1,11 @@
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { globalTeardownMarkerFile } from './constants.mts';
+
+export default async function globalTeardown() {
+    const reportFolder = process.env.MARKER_FOLDER;
+    if (!reportFolder) return;
+    const marker = join(reportFolder, globalTeardownMarkerFile);
+    const count = existsSync(marker) ? parseInt(readFileSync(marker, 'utf-8'), 10) + 1 : 1;
+    writeFileSync(marker, String(count));
+}

--- a/e2e/globalHooks/global.setup.spec.ts
+++ b/e2e/globalHooks/global.setup.spec.ts
@@ -1,0 +1,6 @@
+import { test as setup } from '@playwright/test';
+import globalSetup from './global-setup.mts';
+
+setup('setup', async ({}) => {
+    await globalSetup();
+});

--- a/e2e/globalHooks/global.teardown.spec.ts
+++ b/e2e/globalHooks/global.teardown.spec.ts
@@ -1,0 +1,6 @@
+import { test as teardown } from '@playwright/test';
+import globalTeardown from './global-teardown.mts';
+
+teardown('teardown', async ({}) => {
+    await globalTeardown();
+});

--- a/packages/core/src/adapters/base-test-run-creator.ts
+++ b/packages/core/src/adapters/base-test-run-creator.ts
@@ -9,7 +9,7 @@ import type {
     BaseOptions,
     TestRun,
 } from '../types/adapters.js';
-import type { ReporterTestRun } from '../types/test-info.js';
+import type { Project, ReporterTestRun } from '../types/test-info.js';
 import { RunStatus } from '../types/test-info.js';
 import type { RunInfoLoader } from '../adapters/run-info-loader.js';
 import { cliVersion } from '../commands/version.js';
@@ -30,6 +30,7 @@ export abstract class BaseTestRunCreator implements TestRunCreator {
     async create({ runId, args, options }: SaveTestRunParams): Promise<void> {
         const reporterTestRun = await this.runInfoLoader.load(args);
         let tests = this.transformTestRunToItems(reporterTestRun.testRun, options);
+        tests = this.filterInfrastructureProjects(tests, reporterTestRun.config.projects);
         const testInfos = await this.loadTestInfos(tests);
         tests = this.sortTests(tests, testInfos, {
             historyWindow: options.historyWindow,
@@ -100,6 +101,28 @@ export abstract class BaseTestRunCreator implements TestRunCreator {
             value *= fails / historyWindow + 1;
         }
         return value;
+    }
+
+    private filterInfrastructureProjects(tests: TestItem[], projects: Project[]): TestItem[] {
+        const infraProjects = new Set<string>();
+        for (const project of projects) {
+            for (const dep of project.dependencies) {
+                infraProjects.add(dep);
+            }
+            if (project.teardown) {
+                infraProjects.add(project.teardown);
+            }
+        }
+        if (infraProjects.size === 0) return tests;
+
+        return tests
+            .map((test) => {
+                const filtered = test.projects.filter((p) => !infraProjects.has(p));
+                if (filtered.length === 0) return null;
+                if (filtered.length === test.projects.length) return test;
+                return { ...test, projects: filtered };
+            })
+            .filter((test): test is TestItem => test !== null);
     }
 
     private validateTests(tests: TestItem[]): void {

--- a/packages/core/src/commands/run.ts
+++ b/packages/core/src/commands/run.ts
@@ -10,8 +10,10 @@ import type { BatchHandler } from '../batch/batch-handler.js';
 import { SYMBOLS } from '../symbols.js';
 import { PlaywrightTestEventHandler, TestEventHandler, TestEventHandlerFactory } from '../runner/test-event-handler.js';
 import { WebServerManager } from '../runner/web-server-manager.js';
+import { GlobalSetupManager } from '../runner/global-setup-manager.js';
 import { BrowserManager } from '../runner/browser-manager.js';
 import { TestExecutionReporter } from '../runner/test-execution-reporter.js';
+import { PlaywrightConfigLoader } from '../helpers/playwright-config.js';
 import { Container } from 'inversify';
 import * as uuid from 'uuid';
 
@@ -75,6 +77,8 @@ function registerServices(container: Container) {
     container.bind(SYMBOLS.TestExecutionReporter).to(TestExecutionReporter).inSingletonScope();
     container.bind(SYMBOLS.BrowserManager).to(BrowserManager).inSingletonScope();
     container.bind(SYMBOLS.WebServerManager).to(WebServerManager).inSingletonScope();
+    container.bind(SYMBOLS.GlobalSetupManager).to(GlobalSetupManager).inSingletonScope();
+    container.bind(SYMBOLS.PlaywrightConfigLoader).to(PlaywrightConfigLoader).inSingletonScope();
 
     container.bind<TestRunner>(SYMBOLS.TestRunner).to(TestRunner);
 }

--- a/packages/core/src/helpers/playwright-config.ts
+++ b/packages/core/src/helpers/playwright-config.ts
@@ -1,0 +1,44 @@
+import { createRequire } from 'node:module';
+import { dirname, join, resolve } from 'node:path';
+import { injectable } from 'inversify';
+
+export interface PlaywrightConfig {
+    config: any;
+    configDir: string;
+    globalSetups: string[];
+    globalTeardowns: string[];
+    webServers: any[];
+}
+
+@injectable()
+export class PlaywrightConfigLoader {
+    private cached: PlaywrightConfig | undefined;
+
+    getConfig(): PlaywrightConfig {
+        if (!this.cached) {
+            throw new Error('PlaywrightConfigLoader.load() must be called at least once before accessing the config');
+        }
+        return this.cached;
+    }
+
+    async loadPlaywrightConfig(configFile: string | undefined): Promise<void> {
+        if (!configFile) {
+            throw new Error('No config file provided');
+        }
+        const req = createRequire(join(process.cwd(), 'package.json'));
+        const { loadConfig, resolveConfigLocation } = req('playwright/lib/common/configLoader');
+        const location = resolveConfigLocation(resolve(configFile));
+        this.cached = await loadConfig(location, {});
+    }
+}
+
+export function loadPlaywrightModule(subpath: string): any {
+    const req = createRequire(join(process.cwd(), 'package.json'));
+    try {
+        return req(subpath);
+    } catch {
+        // Fallback to absolute path for modules not in Playwright's exports map
+        const pwDir = dirname(req.resolve('playwright/package.json'));
+        return req(join(pwDir, `${subpath.replace('playwright/', '')}.js`));
+    }
+}

--- a/packages/core/src/helpers/run-playwright.ts
+++ b/packages/core/src/helpers/run-playwright.ts
@@ -1,0 +1,21 @@
+import { spawn } from 'node:child_process';
+import { createInterface } from 'node:readline';
+
+export function runPlaywright(
+    args: string[],
+    onLine?: (line: string, isError: boolean) => void,
+    env?: NodeJS.ProcessEnv,
+): Promise<number | null> {
+    return new Promise((resolve, reject) => {
+        const proc = spawn('npx', ['playwright', 'test', ...args], {
+            env: env ?? process.env,
+            stdio: ['ignore', onLine ? 'pipe' : 'ignore', onLine ? 'pipe' : 'ignore'],
+        });
+        if (onLine) {
+            createInterface({ input: proc.stdout!, crlfDelay: Infinity }).on('line', (line) => onLine(line, false));
+            createInterface({ input: proc.stderr!, crlfDelay: Infinity }).on('line', (line) => onLine(line, true));
+        }
+        proc.on('exit', resolve);
+        proc.on('error', reject);
+    });
+}

--- a/packages/core/src/playwright-tools/run-builder.ts
+++ b/packages/core/src/playwright-tools/run-builder.ts
@@ -35,6 +35,8 @@ export class RunBuilder {
                 name: project.name,
                 use: project.use,
                 repeatEach: project.repeatEach,
+                dependencies: project.dependencies,
+                teardown: project.teardown,
             })),
         };
         return this;

--- a/packages/core/src/runner/global-setup-manager.ts
+++ b/packages/core/src/runner/global-setup-manager.ts
@@ -1,0 +1,169 @@
+import { inject, injectable } from 'inversify';
+import type { TestRunConfig } from '../types/adapters.js';
+import type { Project } from '../types/test-info.js';
+import { SYMBOLS } from '../symbols.js';
+import { TestExecutionReporter } from './test-execution-reporter.js';
+import { loadPlaywrightModule, PlaywrightConfigLoader, type PlaywrightConfig } from '../helpers/playwright-config.js';
+import { runPlaywright } from '../helpers/run-playwright.js';
+
+@injectable()
+export class GlobalSetupManager {
+    private loadGlobalHook: any;
+    private globalSetupTeardowns: Array<() => Promise<void> | void> = [];
+
+    constructor(
+        @inject(SYMBOLS.TestExecutionReporter) private readonly reporter: TestExecutionReporter,
+        @inject(SYMBOLS.PlaywrightConfigLoader) private readonly configLoader: PlaywrightConfigLoader,
+    ) {}
+
+    async runSetup(config: TestRunConfig): Promise<void> {
+        ({ loadGlobalHook: this.loadGlobalHook } = loadPlaywrightModule('playwright/lib/runner/loadUtils'));
+        await this.runGlobalSetup(config);
+        await this.runSetupProjects(config);
+    }
+
+    async runTeardown(config: TestRunConfig): Promise<void> {
+        await this.runTeardownProjects(config);
+        await this.runGlobalTeardown(config);
+    }
+
+    private async runGlobalSetup(config: TestRunConfig): Promise<void> {
+        const playwrightConfig = this.configLoader.getConfig();
+        if (!playwrightConfig?.globalSetups?.length) return;
+
+        const promise = this.executeSetups(playwrightConfig);
+        this.reporter.addLoading(`[ Running global setup ]`, promise);
+        await promise;
+    }
+
+    private async executeSetups(playwrightConfig: PlaywrightConfig): Promise<void> {
+        for (const file of playwrightConfig.globalSetups) {
+            const setupHook = await this.loadGlobalHook(playwrightConfig, file);
+            const teardown = await setupHook(playwrightConfig.config);
+            if (typeof teardown === 'function') {
+                this.globalSetupTeardowns.push(teardown);
+            }
+        }
+    }
+
+    private async runSetupProjects(config: TestRunConfig): Promise<void> {
+        const setupOrder = this.topologicalSort(config.projects);
+        if (setupOrder.length === 0) return;
+
+        for (const projectName of setupOrder) {
+            const promise = this.runDependencyProject(projectName, config);
+            this.reporter.addLoading(`[ Running dependency project "${projectName}" ]`, promise);
+            await promise;
+        }
+    }
+
+    private async runTeardownProjects(config: TestRunConfig): Promise<void> {
+        const projects = this.collectTeardownProjects(config.projects);
+        if (!projects || projects.length === 0) return;
+
+        for (const projectName of projects.reverse()) {
+            const promise = this.runDependencyProject(projectName, config);
+            this.reporter.addLoading(`[ Running teardown project "${projectName}" ]`, promise);
+            await promise;
+        }
+    }
+
+    private async runDependencyProject(projectName: string, config: TestRunConfig): Promise<void> {
+        const args = ['--project', projectName, '--reporter', 'list', ...this.cleanArgs(config.args)];
+        if (config.configFile) {
+            args.push('--config', config.configFile);
+        }
+        await runPlaywright(args).then((code) => {
+            if (code !== 0) throw new Error(`Project "${projectName}" failed with exit code ${code}`);
+        });
+    }
+
+    private cleanArgs(args: string[]): string[] {
+        const filtered: string[] = [];
+        for (let i = 0; i < args.length; i++) {
+            const arg = args[i];
+            if (arg === '--project' && i + 1 < args.length) {
+                i++;
+                continue;
+            }
+            filtered.push(arg);
+        }
+        return filtered;
+    }
+
+    private collectTeardownProjects(projects: Project[]): string[] {
+        const teardownNames = new Set<string>();
+        for (const project of projects) {
+            if (project.teardown) {
+                teardownNames.add(project.teardown);
+            }
+        }
+        return [...teardownNames];
+    }
+
+    private topologicalSort(projects: Project[]): string[] {
+        const dependencyNames = new Set<string>();
+        for (const project of projects) {
+            for (const dep of project.dependencies) {
+                dependencyNames.add(dep);
+            }
+        }
+        if (dependencyNames.size === 0) return [];
+
+        const projectMap = new Map(projects.map((p) => [p.name, p]));
+        const inDegree = new Map<string, number>();
+        const edges = new Map<string, string[]>();
+
+        for (const name of dependencyNames) {
+            inDegree.set(name, 0);
+            edges.set(name, []);
+        }
+
+        for (const name of dependencyNames) {
+            const project = projectMap.get(name);
+            if (!project) continue;
+            for (const dep of project.dependencies) {
+                if (dependencyNames.has(dep)) {
+                    edges.get(dep)!.push(name);
+                    inDegree.set(name, (inDegree.get(name) ?? 0) + 1);
+                }
+            }
+        }
+
+        const queue = [...dependencyNames].filter((n) => inDegree.get(n) === 0);
+        const result: string[] = [];
+
+        while (queue.length > 0) {
+            const node = queue.shift()!;
+            result.push(node);
+            for (const neighbor of edges.get(node) ?? []) {
+                const newDegree = inDegree.get(neighbor)! - 1;
+                inDegree.set(neighbor, newDegree);
+                if (newDegree === 0) queue.push(neighbor);
+            }
+        }
+
+        if (result.length !== dependencyNames.size) {
+            throw new Error('Circular dependency detected among setup projects');
+        }
+        return result;
+    }
+
+    private async runGlobalTeardown(config: TestRunConfig): Promise<void> {
+        const playwrightConfig = this.configLoader.getConfig();
+        if (!playwrightConfig?.globalTeardowns?.length && !this.globalSetupTeardowns.length) return;
+        const promise = this.executeTeardowns(playwrightConfig);
+        this.reporter.addLoading(`[ Running global teardown ]`, promise);
+        await promise;
+    }
+
+    private async executeTeardowns(playwrightConfig: PlaywrightConfig): Promise<void> {
+        for (const teardown of this.globalSetupTeardowns.reverse()) {
+            await teardown();
+        }
+        for (const file of playwrightConfig.globalTeardowns ?? []) {
+            const teardownHook = await this.loadGlobalHook(playwrightConfig, file);
+            await teardownHook(playwrightConfig.config);
+        }
+    }
+}

--- a/packages/core/src/runner/test-event-handler.ts
+++ b/packages/core/src/runner/test-event-handler.ts
@@ -7,7 +7,11 @@ import type { Adapter } from '../adapters/adapter.js';
 import { SYMBOLS } from '../symbols.js';
 import { Project, TestStatus } from '../types/test-info.js';
 
-type HandlerResult = { onData: (data: any) => void; onExit: () => Promise<void>; batchResolver: Resolver };
+type HandlerResult = {
+    onData: (data: any, isError: boolean) => void;
+    onExit: () => Promise<void>;
+    batchResolver: Resolver;
+};
 type Resolver = { success: () => void; fail: (reason?: any) => void };
 
 export interface TestEventHandler {
@@ -39,8 +43,9 @@ export class PlaywrightTestEventHandler implements TestEventHandler {
         this.config = config;
         this.initTests(tests, config, batchName);
 
-        const onData = (data: any) => {
+        const onData = (data: any, isError: boolean) => {
             let event: TestReportEvent;
+            if (isError) return;
             try {
                 event = JSON.parse(data.toString()) as TestReportEvent;
             } catch (error) {

--- a/packages/core/src/runner/test-runner.ts
+++ b/packages/core/src/runner/test-runner.ts
@@ -9,12 +9,13 @@ import type { ShardHandler } from '../adapters/shard-handler.js';
 import type { BatchHandlerFactory } from '../commands/run.js';
 import { BrowserManager } from './browser-manager.js';
 import { WebServerManager } from './web-server-manager.js';
-import { spawn } from 'node:child_process';
-import { createInterface } from 'node:readline';
+import { GlobalSetupManager } from './global-setup-manager.js';
 import { SYMBOLS } from '../symbols.js';
+import { runPlaywright } from '../helpers/run-playwright.js';
 import type { TestEventHandlerFactory } from './test-event-handler.js';
 import { cliVersion } from '../commands/version.js';
 import { registerOnExit } from '../helpers/register-on-exit.js';
+import { PlaywrightConfigLoader } from '../helpers/playwright-config.js';
 
 @injectable()
 export class TestRunner {
@@ -25,9 +26,11 @@ export class TestRunner {
         @inject(SYMBOLS.ShardHandler) private readonly shardHandler: ShardHandler,
         @inject(SYMBOLS.BrowserManager) private readonly browserManager: BrowserManager,
         @inject(SYMBOLS.WebServerManager) private readonly webServerManager: WebServerManager,
+        @inject(SYMBOLS.GlobalSetupManager) private readonly globalSetupManager: GlobalSetupManager,
         @inject(SYMBOLS.BatchHandlerFactory) private readonly batchHandlerFactory: BatchHandlerFactory,
         @inject(SYMBOLS.TestExecutionReporter) private readonly reporter: TestExecutionReporter,
         @inject(SYMBOLS.TestEventHandlerFactory) private readonly testEventHandlerFactory: TestEventHandlerFactory,
+        @inject(SYMBOLS.PlaywrightConfigLoader) private readonly configLoader: PlaywrightConfigLoader,
     ) {
         registerOnExit(() => {
             this.cleanupTemp();
@@ -44,18 +47,21 @@ export class TestRunner {
             process.exitCode = 1;
             return false;
         }
+        await this.configLoader.loadPlaywrightConfig(config.configFile);
         const [browsers] = await Promise.all([
             this.browserManager.runBrowsers(config),
-            this.webServerManager.startServers(config),
+            this.webServerManager.startServers(),
         ]);
         config.configFile = await this.createTempConfig(config.configFile);
         if (config.configFile) {
             this.cleanupFs.add(config.configFile);
         }
+        await this.globalSetupManager.runSetup(config);
 
         try {
             await this.runTestsUntilAvailable(config, browsers);
         } finally {
+            await this.globalSetupManager.runTeardown(config);
             this.reporter.printSummary();
             await this.shardHandler.finishShard();
         }
@@ -106,20 +112,15 @@ export class TestRunner {
 
         const batchArtifact = path.relative(process.cwd(), `${this.runContext.outputFolder}/${batchId}.zip`);
         try {
-            await new Promise<void>((resolve, reject) => {
-                const playwright = spawn('npx', ['playwright', 'test', ...this.buildParams(tests, config)], {
-                    env: {
-                        ...process.env,
-                        PLAYWRIGHT_BLOB_OUTPUT_FILE: batchArtifact,
-                        ...(config.configFile && {
-                            PLAYWRIGHT_ORCHESTRATOR_BROWSERS: JSON.stringify(browsers),
-                        }),
-                        PLAYWRIGHT_ORCHESTRATOR_GROUPING: config.options.grouping,
-                    },
-                });
-                createInterface({ input: playwright.stdout, crlfDelay: Infinity }).on('line', onData);
-                playwright.on('exit', () => onExit().then(resolve, reject));
+            await runPlaywright(this.buildParams(tests, config), onData, {
+                ...process.env,
+                PLAYWRIGHT_BLOB_OUTPUT_FILE: batchArtifact,
+                ...(config.configFile && {
+                    PLAYWRIGHT_ORCHESTRATOR_BROWSERS: JSON.stringify(browsers),
+                }),
+                PLAYWRIGHT_ORCHESTRATOR_GROUPING: config.options.grouping,
             });
+            await onExit();
             batchResolver.success();
         } catch (err) {
             batchResolver.fail(err);
@@ -150,7 +151,6 @@ export class TestRunner {
 
     private async createTempConfig(file: string | undefined): Promise<string | undefined> {
         if (!file) return;
-        // Remove webServer from config (not supported in the orchestrator).
         // Browser endpoints are injected via PLAYWRIGHT_ORCHESTRATOR_BROWSERS env var.
         const content = `
 import config from '${path.resolve(file)}';
@@ -158,12 +158,16 @@ import config from '${path.resolve(file)}';
 const browsers: Record<string, string> = JSON.parse(process.env.PLAYWRIGHT_ORCHESTRATOR_BROWSERS ?? '{}');
 
 config.webServer = undefined;
+config.globalSetup = undefined;
+config.globalTeardown = undefined;
 for (const project of config?.projects ?? []) {
     if (!project.use) project.use = {};
     if (!project.use.connectOptions) project.use.connectOptions = {};
     if (!project.use.connectOptions.wsEndpoint) {
         project.use.connectOptions.wsEndpoint = browsers[project.name!];
     }
+    project.dependencies = [];
+    project.teardown = undefined;
 }
 
 export default config;`;

--- a/packages/core/src/runner/web-server-manager.ts
+++ b/packages/core/src/runner/web-server-manager.ts
@@ -1,43 +1,36 @@
 import { inject, injectable, preDestroy } from 'inversify';
-import { createRequire } from 'node:module';
-import { join, resolve } from 'node:path';
 import type { TestRunConfig } from '../types/adapters.js';
 import { SYMBOLS } from '../symbols.js';
 import { TestExecutionReporter } from './test-execution-reporter.js';
+import { loadPlaywrightModule, PlaywrightConfigLoader } from '../helpers/playwright-config.js';
 
 @injectable()
 export class WebServerManager {
     private plugins: any[] = [];
 
-    constructor(@inject(SYMBOLS.TestExecutionReporter) private readonly reporter: TestExecutionReporter) {}
+    constructor(
+        @inject(SYMBOLS.TestExecutionReporter) private readonly reporter: TestExecutionReporter,
+        @inject(SYMBOLS.PlaywrightConfigLoader) private readonly configLoader: PlaywrightConfigLoader,
+    ) {}
 
-    async startServers(config: TestRunConfig): Promise<void> {
-        if (!config.configFile) return;
+    async startServers(): Promise<void> {
+        const playwrightConfig = this.configLoader.getConfig();
+        if (!playwrightConfig?.webServers?.length) return;
 
-        const req = createRequire(join(process.cwd(), 'package.json'));
-        let loadConfig: any, resolveConfigLocation: any, webServer: any;
-        try {
-            ({ loadConfig, resolveConfigLocation } = req('playwright/lib/common/configLoader'));
-            ({ webServer } = req('playwright/lib/plugins'));
-        } catch (e) {
-            this.reporter.error(`Failed to load Playwright's webServer plugin.`);
-            throw e;
-        }
-        const location = resolveConfigLocation(resolve(config.configFile));
-        const fullConfig = await loadConfig(location, {});
-
-        if (!fullConfig.webServers?.length) return;
+        const { webServer } = loadPlaywrightModule('playwright/lib/plugins');
 
         const minimalReporter = {
             onStdOut: (text: string) => this.reporter.info(text),
             onStdErr: (text: string) => this.reporter.error(text),
         };
 
-        this.plugins = fullConfig.webServers.map((s: any) =>
+        this.plugins = playwrightConfig.webServers.map((s: any) =>
             webServer({ ...s, url: s.url || `http://localhost:${s.port}` }),
         );
 
-        const promise = Promise.all(this.plugins.map((p: any) => p.setup(null, fullConfig.configDir, minimalReporter)));
+        const promise = Promise.all(
+            this.plugins.map((p: any) => p.setup(null, playwrightConfig.configDir, minimalReporter)),
+        );
         this.reporter.addLoading('[ Starting web servers ]', promise);
         await promise;
     }

--- a/packages/core/src/symbols.ts
+++ b/packages/core/src/symbols.ts
@@ -13,4 +13,6 @@ export const SYMBOLS = {
     TestEventHandler: Symbol.for('TestEventHandler'),
     TestEventHandlerFactory: Symbol.for('TestEventHandlerFactory'),
     RunContext: Symbol.for('RunContext'),
+    GlobalSetupManager: Symbol.for('GlobalSetupManager'),
+    PlaywrightConfigLoader: Symbol.for('PlaywrightConfigLoader'),
 } as const;

--- a/packages/core/src/types/test-info.ts
+++ b/packages/core/src/types/test-info.ts
@@ -6,6 +6,8 @@ export interface Project {
     name: string;
     use: UseOptions;
     repeatEach: number;
+    dependencies: string[];
+    teardown?: string;
 }
 
 export interface TestConfig {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -36,14 +36,28 @@ export default defineConfig({
     /* Configure projects for major browsers */
     projects: [
         {
+            name: 'setup',
+            testDir: './e2e/globalHooks',
+            testMatch: 'global.setup.spec.ts',
+        },
+        {
+            name: 'teardown',
+            testDir: './e2e/globalHooks',
+            testMatch: 'global.teardown.spec.ts',
+        },
+        {
             name: 'chromium',
             use: { ...devices['Desktop Chrome'] },
             outputDir: './test-results/chromium',
+            dependencies: ['setup'],
+            teardown: 'teardown',
         },
 
         {
             name: 'firefox',
             use: { ...devices['Desktop Firefox'] },
+            dependencies: ['setup'],
+            teardown: 'teardown',
         },
 
         // {

--- a/scripts/check-playwright-internals.js
+++ b/scripts/check-playwright-internals.js
@@ -63,7 +63,14 @@ check('playwright/lib/plugins.webServer', () => {
     assert(typeof m.webServer === 'function', `webServer is ${typeof m.webServer} (expected function)`);
 });
 
-// ── Check 4: Suite._parallelMode ─────────────────────────────────────────────
+// ── Check 4: playwright/lib/runner/loadUtils.loadGlobalHook ──────────────────
+check('playwright/lib/runner/loadUtils.loadGlobalHook', () => {
+    const pwDir = path.dirname(req.resolve('playwright/package.json'));
+    const m = require(path.join(pwDir, 'lib/runner/loadUtils.js'));
+    assert(typeof m.loadGlobalHook === 'function', `loadGlobalHook is ${typeof m.loadGlobalHook} (expected function)`);
+});
+
+// ── Check 5: Suite._parallelMode ─────────────────────────────────────────────
 // _parallelMode is an instance property set in the Suite constructor.
 // We load the Suite class by its absolute path to bypass package exports restrictions,
 // then instantiate it and verify the property is present on the instance — exactly

--- a/tests-playwright.config.ts
+++ b/tests-playwright.config.ts
@@ -1,5 +1,6 @@
 import config from './playwright.config';
 
 config.testDir = './e2e/test-simulation';
-
+config.globalSetup = require.resolve('./e2e/globalHooks/global-setup.mts');
+config.globalTeardown = require.resolve('./e2e/globalHooks/global-teardown.mts');
 export default config;

--- a/tests/__snapshots__/test-report-project.report.snap
+++ b/tests/__snapshots__/test-report-project.report.snap
@@ -13,8 +13,30 @@
     },
     "projects": [
       {
+        "dependencies": [],
+        "name": "setup",
+        "repeatEach": 1,
+        "use": {
+          "baseURL": "http://localhost:4321",
+          "trace": "on-first-retry"
+        }
+      },
+      {
+        "dependencies": [],
+        "name": "teardown",
+        "repeatEach": 1,
+        "use": {
+          "baseURL": "http://localhost:4321",
+          "trace": "on-first-retry"
+        }
+      },
+      {
+        "dependencies": [
+          "setup"
+        ],
         "name": "chromium",
         "repeatEach": 1,
+        "teardown": "teardown",
         "use": {
           "baseURL": "http://localhost:4321",
           "defaultBrowserType": "chromium",
@@ -34,8 +56,12 @@
         }
       },
       {
+        "dependencies": [
+          "setup"
+        ],
         "name": "firefox",
         "repeatEach": 1,
+        "teardown": "teardown",
         "use": {
           "baseURL": "http://localhost:4321",
           "defaultBrowserType": "firefox",

--- a/tests/__snapshots__/test-report-test.report.snap
+++ b/tests/__snapshots__/test-report-test.report.snap
@@ -13,8 +13,30 @@
     },
     "projects": [
       {
+        "dependencies": [],
+        "name": "setup",
+        "repeatEach": 1,
+        "use": {
+          "baseURL": "http://localhost:4321",
+          "trace": "on-first-retry"
+        }
+      },
+      {
+        "dependencies": [],
+        "name": "teardown",
+        "repeatEach": 1,
+        "use": {
+          "baseURL": "http://localhost:4321",
+          "trace": "on-first-retry"
+        }
+      },
+      {
+        "dependencies": [
+          "setup"
+        ],
         "name": "chromium",
         "repeatEach": 1,
+        "teardown": "teardown",
         "use": {
           "baseURL": "http://localhost:4321",
           "defaultBrowserType": "chromium",
@@ -34,8 +56,12 @@
         }
       },
       {
+        "dependencies": [
+          "setup"
+        ],
         "name": "firefox",
         "repeatEach": 1,
+        "teardown": "teardown",
         "use": {
           "baseURL": "http://localhost:4321",
           "defaultBrowserType": "firefox",

--- a/tests/test-sort-pipeline.test.ts
+++ b/tests/test-sort-pipeline.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { BaseTestRunCreator } from '../packages/core/src/adapters/base-test-run-creator.js';
 import type { TestItem, TestSortItem, TestRun, BaseOptions } from '../packages/core/src/types/adapters.js';
 import { Grouping, BatchMode } from '../packages/core/src/types/adapters.js';
-import type { ReporterTestRunInfo } from '../packages/core/src/types/test-info.js';
+import type { Project, ReporterTestRunInfo } from '../packages/core/src/types/test-info.js';
 
 class TestableCreator extends BaseTestRunCreator {
     testInfoMap: Map<string, TestSortItem> = new Map();
@@ -19,8 +19,8 @@ class TestableCreator extends BaseTestRunCreator {
     }
 }
 
-function makeRunInfo(testRun: ReporterTestRunInfo['testRun']): ReporterTestRunInfo {
-    return { testRun, config: { workers: 1, projects: [] } };
+function makeRunInfo(testRun: ReporterTestRunInfo['testRun'], projects: Project[] = []): ReporterTestRunInfo {
+    return { testRun, config: { workers: 1, projects } };
 }
 
 function makeOptions(overrides: Partial<BaseOptions> = {}): BaseOptions {
@@ -153,6 +153,60 @@ describe('BaseTestRunCreator grouping modes', () => {
         expect(creator.savedTests).toHaveLength(2);
         const ids = creator.savedTests.map((t) => t.testId).sort();
         expect(ids).toEqual(['[chrome] a.spec.ts > test a', '[firefox] a.spec.ts > test a']);
+    });
+});
+
+describe('BaseTestRunCreator infrastructure project filtering', () => {
+    const projects: Project[] = [
+        { name: 'setup', use: {} as any, repeatEach: 1, dependencies: [], teardown: undefined },
+        { name: 'teardown', use: {} as any, repeatEach: 1, dependencies: [], teardown: undefined },
+        { name: 'chromium', use: {} as any, repeatEach: 1, dependencies: ['setup'], teardown: 'teardown' },
+    ];
+
+    it('filters out tests from dependency/teardown projects', async () => {
+        const runInfo = makeRunInfo(
+            {
+                'setup.spec.ts': { '1:1': { timeout: 5000, projects: ['setup'], title: 'setup', annotations: [], children: undefined } },
+                'teardown.spec.ts': { '1:1': { timeout: 5000, projects: ['teardown'], title: 'teardown', annotations: [], children: undefined } },
+                'a.spec.ts': { '1:1': { timeout: 5000, projects: ['chromium'], title: 'test a', annotations: [], children: undefined } },
+            },
+            projects,
+        );
+        const creator = makeCreator(runInfo);
+        await creator.create({ runId: 'r', args: [], options: makeOptions() });
+
+        expect(creator.savedTests).toHaveLength(1);
+        expect(creator.savedTests[0].testId).toBe('[chromium] a.spec.ts > test a');
+    });
+
+    it('strips infrastructure projects from mixed-project tests', async () => {
+        const runInfo = makeRunInfo(
+            {
+                'a.spec.ts': { '1:1': { timeout: 5000, projects: ['setup', 'chromium'], title: 'test a', annotations: [], children: undefined } },
+            },
+            projects,
+        );
+        const creator = makeCreator(runInfo);
+        await creator.create({ runId: 'r', args: [], options: makeOptions() });
+
+        expect(creator.savedTests).toHaveLength(1);
+        expect(creator.savedTests[0].projects).toEqual(['chromium']);
+    });
+
+    it('keeps all tests when no dependencies are configured', async () => {
+        const noDeps: Project[] = [
+            { name: 'chromium', use: {} as any, repeatEach: 1, dependencies: [], teardown: undefined },
+        ];
+        const runInfo = makeRunInfo(
+            {
+                'a.spec.ts': { '1:1': { timeout: 5000, projects: ['chromium'], title: 'test a', annotations: [], children: undefined } },
+            },
+            noDeps,
+        );
+        const creator = makeCreator(runInfo);
+        await creator.create({ runId: 'r', args: [], options: makeOptions() });
+
+        expect(creator.savedTests).toHaveLength(1);
     });
 });
 

--- a/tests/utils/test-storage.ts
+++ b/tests/utils/test-storage.ts
@@ -2,9 +2,12 @@ import { expect } from 'vitest';
 import { spawnAsync } from '../../packages/core/src/helpers/spawn.js';
 import { createRequire } from 'node:module';
 import { dirname, join } from 'node:path';
+import { readFileSync } from 'node:fs';
 import type { Grouping } from '../../packages/core/src/types/adapters.js';
 import { TestRunReport } from '../../packages/core/src/types/reporter.js';
 import { cliVersion } from '../../packages/core/src/commands/version.js';
+import { tmpdir } from 'node:os';
+import { globalSetupMarkerFile, globalTeardownMarkerFile } from '../../e2e/globalHooks/constants.mts';
 
 const req = createRequire(join(process.cwd(), 'package.json'));
 const orchestratorCli = req.resolve('@playwright-orchestrator/core/cli');
@@ -37,10 +40,20 @@ export async function testStorage(storageOptions: string[], reportsFolder: strin
     // run command
     const command = [orchestratorCli, 'run', ...storageOptions, '--run-id', runId, '--output', reportsFolder];
     const shardIds = ['shard1', 'shard2'];
+    const globalMarkerFolder = join(tmpdir(), `playwright-orchestrator-test-${runId}`);
     const beforeRun = Date.now();
     const shardResults = await Promise.all(
-        shardIds.map((shardId) => spawnAsync(process.execPath, [...command, '--shard-id', shardId])),
+        shardIds.map((shardId) =>
+            spawnAsync(process.execPath, [...command, '--shard-id', shardId], {
+                env: { ...process.env, MARKER_FOLDER: globalMarkerFolder },
+            }),
+        ),
     );
+    const setupMarker = readFileSync(join(globalMarkerFolder, globalSetupMarkerFile), 'utf-8');
+    const teardownMarker = readFileSync(join(globalMarkerFolder, globalTeardownMarkerFile), 'utf-8');
+    // global setup and teardown + deps should be executed once per shard, so the marker files should contain the number of shards * 2
+    expect(setupMarker).toBe((shardIds.length * 2).toString());
+    expect(teardownMarker).toBe((shardIds.length * 2).toString());
     expect(
         shardResults.every(({ stderr }) => !stderr.toLocaleLowerCase().includes('error')),
         `Run command failed. Errors: ${shardResults.map(({ stderr }) => stderr).join('\n')}`,

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -15,6 +15,7 @@
         "sourceMap": true,
         "composite": true,
         "experimentalDecorators": true,
-        "emitDecoratorMetadata": true
+        "emitDecoratorMetadata": true,
+        "types": ["node"]
     }
 }


### PR DESCRIPTION
Handle Playwright's globalSetup, globalTeardown, project dependencies, and project teardown when orchestrating tests. Infrastructure projects (dependencies/teardowns) are filtered out from test scheduling and executed separately via GlobalSetupManager. Extracts shared Playwright config loading into PlaywrightConfigLoader and subprocess spawning into runPlaywright helper.