### PR TITLE
fix: resolve playwright CLI directly and parse run info line-by-line

### DIFF
--- a/packages/core/src/adapters/playwright-run-info-loader.ts
+++ b/packages/core/src/adapters/playwright-run-info-loader.ts
@@ -1,23 +1,32 @@
 import { injectable } from 'inversify';
 import type { RunInfoLoader } from './run-info-loader.js';
 import type { ReporterTestRunInfo } from '../types/test-info.js';
-import { spawnAsync } from '../helpers/spawn.js';
-import { createRequire } from 'node:module';
-import { dirname, join } from 'node:path';
+import { runPlaywright } from '../helpers/run-playwright.js';
 
 @injectable()
 export class PlaywrightRunInfoLoader implements RunInfoLoader {
     async load(args: string[]): Promise<ReporterTestRunInfo> {
-        const req = createRequire(join(process.cwd(), 'package.json'));
-        const playwrightCli = join(dirname(req.resolve('@playwright/test/package.json')), 'cli.js');
-        const { stdout } = await spawnAsync(process.execPath, [
-            playwrightCli,
-            'test',
-            ...args,
-            '--list',
-            '--reporter',
-            '@playwright-orchestrator/core/run-info-reporter',
-        ]);
-        return JSON.parse(stdout) as ReporterTestRunInfo;
+        let parsedRunInfo: ReporterTestRunInfo | null = null;
+        let stdout = '';
+        await runPlaywright(
+            [...args, '--list', '--reporter', '@playwright-orchestrator/core/run-info-reporter'],
+            (line, isError) => {
+                if (isError) {
+                    console.error(line); // Log Playwright errors to the console
+                } else {
+                    stdout += `${line}\n`; // Accumulate stdout to parse the final run info
+                    try {
+                        const value = JSON.parse(line) as ReporterTestRunInfo;
+                        if (value.config && value.testRun) {
+                            parsedRunInfo = value;
+                        }
+                    } catch {}
+                }
+            },
+        );
+        if (!parsedRunInfo) {
+            throw new Error(`Failed to load run info. Output:\n${stdout}`);
+        }
+        return parsedRunInfo!;
     }
 }

--- a/packages/core/src/helpers/playwright-config.ts
+++ b/packages/core/src/helpers/playwright-config.ts
@@ -10,6 +10,8 @@ export interface PlaywrightConfig {
     webServers: any[];
 }
 
+const req = createRequire(join(process.cwd(), 'package.json'));
+
 @injectable()
 export class PlaywrightConfigLoader {
     private cached: PlaywrightConfig | undefined;
@@ -25,7 +27,6 @@ export class PlaywrightConfigLoader {
         if (!configFile) {
             throw new Error('No config file provided');
         }
-        const req = createRequire(join(process.cwd(), 'package.json'));
         const { loadConfig, resolveConfigLocation } = req('playwright/lib/common/configLoader');
         const location = resolveConfigLocation(resolve(configFile));
         this.cached = await loadConfig(location, {});
@@ -33,7 +34,6 @@ export class PlaywrightConfigLoader {
 }
 
 export function loadPlaywrightModule(subpath: string): any {
-    const req = createRequire(join(process.cwd(), 'package.json'));
     try {
         return req(subpath);
     } catch {

--- a/packages/core/src/helpers/run-playwright.ts
+++ b/packages/core/src/helpers/run-playwright.ts
@@ -1,5 +1,10 @@
 import { spawn } from 'node:child_process';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
 import { createInterface } from 'node:readline';
+
+const req = createRequire(join(process.cwd(), 'package.json'));
+const playwrightCli = join(dirname(req.resolve('@playwright/test/package.json')), 'cli.js');
 
 export function runPlaywright(
     args: string[],
@@ -7,7 +12,7 @@ export function runPlaywright(
     env?: NodeJS.ProcessEnv,
 ): Promise<number | null> {
     return new Promise((resolve, reject) => {
-        const proc = spawn('npx', ['playwright', 'test', ...args], {
+        const proc = spawn(process.execPath, [playwrightCli, 'test', ...args], {
             env: env ?? process.env,
             stdio: ['ignore', onLine ? 'pipe' : 'ignore', onLine ? 'pipe' : 'ignore'],
         });
@@ -15,7 +20,7 @@ export function runPlaywright(
             createInterface({ input: proc.stdout!, crlfDelay: Infinity }).on('line', (line) => onLine(line, false));
             createInterface({ input: proc.stderr!, crlfDelay: Infinity }).on('line', (line) => onLine(line, true));
         }
-        proc.on('exit', resolve);
+        proc.on('close', resolve);
         proc.on('error', reject);
     });
 }


### PR DESCRIPTION
Replace npx spawn with direct CLI path resolution via createRequire so run-playwright works without npx on PATH. Parse run-info reporter output line-by-line to tolerate extra stdout noise.