### PR TITLE
feat: support Playwright 1.60+ internal API restructuring

### DIFF
--- a/e2e/globalHooks/global-setup.mts
+++ b/e2e/globalHooks/global-setup.mts
@@ -1,12 +1,18 @@
 import { readFileSync, existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { globalSetupMarkerFile } from './constants.mts';
+import { lock } from 'proper-lockfile';
 
 export default async function globalSetup() {
     const reportFolder = process.env.MARKER_FOLDER;
     if (!reportFolder) return;
     mkdirSync(reportFolder, { recursive: true });
     const marker = join(reportFolder, globalSetupMarkerFile);
-    const count = existsSync(marker) ? parseInt(readFileSync(marker, 'utf-8'), 10) + 1 : 1;
+    if (!existsSync(marker)) {
+        writeFileSync(marker, '0');
+    }
+    const release = await lock(marker, { retries: 100 });
+    const count = parseInt(readFileSync(marker, 'utf-8'), 10) + 1;
     writeFileSync(marker, String(count));
+    await release();
 }

--- a/e2e/globalHooks/global-teardown.mts
+++ b/e2e/globalHooks/global-teardown.mts
@@ -1,11 +1,17 @@
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { globalTeardownMarkerFile } from './constants.mts';
+import { lock } from 'proper-lockfile';
 
 export default async function globalTeardown() {
     const reportFolder = process.env.MARKER_FOLDER;
     if (!reportFolder) return;
     const marker = join(reportFolder, globalTeardownMarkerFile);
-    const count = existsSync(marker) ? parseInt(readFileSync(marker, 'utf-8'), 10) + 1 : 1;
+    if (!existsSync(marker)) {
+        writeFileSync(marker, '0');
+    }
+    const release = await lock(marker, { retries: 100 });
+    const count = parseInt(readFileSync(marker, 'utf-8'), 10) + 1;
     writeFileSync(marker, String(count));
+    await release();
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "playwright-orchestrator",
     "version": "1.4.2",
     "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
     },
     "packageManager": "pnpm@10.28.0",
     "directories": {
@@ -45,7 +45,9 @@
             "@playwright-orchestrator/mongo": "workspace:*",
             "@playwright-orchestrator/mysql": "workspace:*",
             "@playwright-orchestrator/pg": "workspace:*",
-            "@playwright-orchestrator/redis": "workspace:*"
+            "@playwright-orchestrator/redis": "workspace:*",
+            "@playwright/test": "^1.60.0",
+            "playwright": "^1.60.0"
         }
     },
     "devDependencies": {
@@ -56,16 +58,19 @@
         "@playwright-orchestrator/mysql": "workspace:*",
         "@playwright-orchestrator/pg": "workspace:*",
         "@playwright-orchestrator/redis": "workspace:*",
-        "@playwright/test": "^1.49.1",
+        "@playwright/test": "^1.60.0",
+        "@testcontainers/mysql": "^10.0.0",
+        "@testcontainers/postgresql": "^10.0.0",
+        "@testcontainers/redis": "^10.0.0",
+        "@types/proper-lockfile": "^4.1.4",
         "@types/node": "^22.10.2",
         "esbuild": "^0.27.4",
-        "playwright": "^1.49.1",
+        "playwright": "^1.60.0",
         "prettier": "3.4.2",
-        "typescript": "^5.7.3",
-        "vitest": "^3.0.5",
+        "proper-lockfile": "^4.1.2",
         "testcontainers": "^10.0.0",
-        "@testcontainers/postgresql": "^10.0.0",
-        "@testcontainers/mysql": "^10.0.0",
-        "@testcontainers/redis": "^10.0.0"
-    }
+        "typescript": "^5.7.3",
+        "vitest": "^3.0.5"
+    },
+    "dependencies": {}
 }

--- a/packages/core/src/helpers/playwright-config.ts
+++ b/packages/core/src/helpers/playwright-config.ts
@@ -12,6 +12,14 @@ export interface PlaywrightConfig {
 
 const req = createRequire(join(process.cwd(), 'package.json'));
 
+function isModuleResolutionError(e: any): boolean {
+    return e.code === 'MODULE_NOT_FOUND' || e.code === 'ERR_PACKAGE_PATH_NOT_EXPORTED' || e.code === 'ERR_UNSUPPORTED_DIR_IMPORT';
+}
+
+function loadPwAbsolute(relPath: string): any {
+    return req(join(dirname(req.resolve('playwright/package.json')), relPath));
+}
+
 @injectable()
 export class PlaywrightConfigLoader {
     private cached: PlaywrightConfig | undefined;
@@ -27,18 +35,86 @@ export class PlaywrightConfigLoader {
         if (!configFile) {
             throw new Error('No config file provided');
         }
-        const { loadConfig, resolveConfigLocation } = req('playwright/lib/common/configLoader');
+        const { loadConfig, resolveConfigLocation } = loadConfigFunctions();
         const location = resolveConfigLocation(resolve(configFile));
         this.cached = await loadConfig(location, {});
     }
 }
 
+function loadConfigFunctions(): { loadConfig: Function; resolveConfigLocation: Function } {
+    // Old Playwright: direct subpath require (pre-1.50)
+    try {
+        const m = req('playwright/lib/common/configLoader');
+        if (typeof m.loadConfig === 'function') return m;
+    } catch (e: any) {
+        if (!isModuleResolutionError(e)) throw e;
+    }
+    // Old Playwright: absolute path (exports map restriction but file exists)
+    try {
+        const m = loadPwAbsolute('lib/common/configLoader.js');
+        if (typeof m.loadConfig === 'function') return m;
+    } catch (e: any) {
+        if (!isModuleResolutionError(e)) throw e;
+    }
+    // Playwright 1.60+: consolidated into lib/common/index.js under configLoader namespace
+    const m = loadPwAbsolute('lib/common/index.js');
+    const loader = m.configLoader;
+    if (!loader || typeof loader.loadConfig !== 'function') {
+        throw new Error('Cannot find loadConfig in Playwright internals (checked configLoader.js and index.js#configLoader)');
+    }
+    return loader;
+}
+
+// Maps old subpaths to their new consolidated locations in Playwright 1.60+
+const CONSOLIDATED_MODULES: Record<string, { file: string; namespace?: string }> = {
+    'lib/plugins': { file: 'lib/runner/index.js' },
+    'lib/runner/loadUtils': { file: 'lib/runner/index.js' },
+    'lib/common/configLoader': { file: 'lib/common/index.js', namespace: 'configLoader' },
+    'lib/common/test': { file: 'lib/common/index.js', namespace: 'test' },
+};
+
 export function loadPlaywrightModule(subpath: string): any {
+    // Try package subpath first (works in old Playwright without exports restrictions)
     try {
         return req(subpath);
-    } catch {
-        // Fallback to absolute path for modules not in Playwright's exports map
-        const pwDir = dirname(req.resolve('playwright/package.json'));
-        return req(join(pwDir, `${subpath.replace('playwright/', '')}.js`));
+    } catch (e: any) {
+        if (!isModuleResolutionError(e)) throw e;
     }
+    const relPath = subpath.replace('playwright/', '');
+    // Try absolute path (handles exports map restrictions in some older versions)
+    try {
+        return loadPwAbsolute(`${relPath}.js`);
+    } catch (e: any) {
+        if (!isModuleResolutionError(e)) throw e;
+    }
+    // Playwright 1.60+: modules consolidated into index.js files
+    const mapping = CONSOLIDATED_MODULES[relPath];
+    if (!mapping) throw new Error(`Cannot load Playwright module: ${subpath}`);
+    const m = loadPwAbsolute(mapping.file);
+    const result = mapping.namespace ? m[mapping.namespace] : m;
+    if (result == null) throw new Error(`Cannot load Playwright module: ${subpath} (namespace '${mapping.namespace}' not found in ${mapping.file})`);
+    return result;
+}
+
+export function loadGlobalHookFn(): (config: PlaywrightConfig, file: string) => Promise<Function> {
+    // Old Playwright: loadGlobalHook exported from loadUtils
+    try {
+        const m = loadPlaywrightModule('playwright/lib/runner/loadUtils');
+        if (typeof m.loadGlobalHook === 'function') return m.loadGlobalHook;
+    } catch (e: any) {
+        if (!isModuleResolutionError(e)) throw e;
+    }
+    // Playwright 1.60+: loadGlobalHook removed from exports, use transform.requireOrImport
+    const common = loadPwAbsolute('lib/common/index.js');
+    const requireOrImport: ((file: string) => Promise<unknown>) | undefined = common.transform?.requireOrImport;
+    if (typeof requireOrImport !== 'function') {
+        throw new Error('Cannot find loadGlobalHook or transform.requireOrImport in Playwright internals');
+    }
+    return async (config: PlaywrightConfig, file: string) => {
+        const resolvedPath = resolve(config.config.rootDir, file);
+        let fn = await requireOrImport(resolvedPath);
+        if (fn && typeof fn === 'object' && 'default' in fn) fn = (fn as any).default;
+        if (typeof fn !== 'function') throw new Error(`${file} must export a single function`);
+        return fn;
+    };
 }

--- a/packages/core/src/runner/global-setup-manager.ts
+++ b/packages/core/src/runner/global-setup-manager.ts
@@ -3,7 +3,7 @@ import type { TestRunConfig } from '../types/adapters.js';
 import type { Project } from '../types/test-info.js';
 import { SYMBOLS } from '../symbols.js';
 import { TestExecutionReporter } from './test-execution-reporter.js';
-import { loadPlaywrightModule, PlaywrightConfigLoader, type PlaywrightConfig } from '../helpers/playwright-config.js';
+import { loadGlobalHookFn, PlaywrightConfigLoader, type PlaywrightConfig } from '../helpers/playwright-config.js';
 import { runPlaywright } from '../helpers/run-playwright.js';
 
 @injectable()
@@ -17,7 +17,7 @@ export class GlobalSetupManager {
     ) {}
 
     async runSetup(config: TestRunConfig): Promise<void> {
-        ({ loadGlobalHook: this.loadGlobalHook } = loadPlaywrightModule('playwright/lib/runner/loadUtils'));
+        this.loadGlobalHook = loadGlobalHookFn();
         await this.runGlobalSetup(config);
         await this.runSetupProjects(config);
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,8 @@ overrides:
   '@playwright-orchestrator/mysql': workspace:*
   '@playwright-orchestrator/pg': workspace:*
   '@playwright-orchestrator/redis': workspace:*
+  '@playwright/test': ^1.60.0
+  playwright: ^1.60.0
 
 importers:
 
@@ -39,8 +41,8 @@ importers:
         specifier: workspace:*
         version: link:packages/redis
       '@playwright/test':
-        specifier: ^1.49.1
-        version: 1.58.2
+        specifier: ^1.60.0
+        version: 1.60.0
       '@testcontainers/mysql':
         specifier: ^10.0.0
         version: 10.28.0
@@ -53,15 +55,21 @@ importers:
       '@types/node':
         specifier: ^22.10.2
         version: 22.19.15
+      '@types/proper-lockfile':
+        specifier: ^4.1.4
+        version: 4.1.4
       esbuild:
         specifier: ^0.27.4
         version: 0.27.4
       playwright:
-        specifier: ^1.49.1
-        version: 1.58.2
+        specifier: ^1.60.0
+        version: 1.60.0
       prettier:
         specifier: 3.4.2
         version: 3.4.2
+      proper-lockfile:
+        specifier: ^4.1.2
+        version: 4.1.2
       testcontainers:
         specifier: ^10.0.0
         version: 10.28.0
@@ -99,8 +107,8 @@ importers:
         specifier: workspace:*
         version: link:../redis
       '@playwright/test':
-        specifier: ^1.44.0
-        version: 1.58.2
+        specifier: ^1.60.0
+        version: 1.60.0
       boxen:
         specifier: ^8.0.1
         version: 8.0.1
@@ -117,8 +125,8 @@ importers:
         specifier: ^6.1.0
         version: 6.1.0
       playwright:
-        specifier: ^1.44.0
-        version: 1.58.2
+        specifier: ^1.60.0
+        version: 1.60.0
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -413,8 +421,20 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.27.4':
     resolution: {integrity: sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -425,8 +445,20 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.27.4':
     resolution: {integrity: sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -437,8 +469,20 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.27.4':
     resolution: {integrity: sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -449,8 +493,20 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.27.4':
     resolution: {integrity: sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -461,8 +517,20 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.27.4':
     resolution: {integrity: sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -473,8 +541,20 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.27.4':
     resolution: {integrity: sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -485,8 +565,20 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.27.4':
     resolution: {integrity: sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -497,8 +589,20 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.27.4':
     resolution: {integrity: sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -509,8 +613,20 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/netbsd-arm64@0.27.4':
     resolution: {integrity: sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -521,8 +637,20 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/openbsd-arm64@0.27.4':
     resolution: {integrity: sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -533,8 +661,20 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openharmony-arm64@0.27.4':
     resolution: {integrity: sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -545,8 +685,20 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/win32-arm64@0.27.4':
     resolution: {integrity: sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -557,8 +709,20 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.27.4':
     resolution: {integrity: sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -620,8 +784,8 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
-  '@playwright/test@1.58.2':
-    resolution: {integrity: sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==}
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -1343,6 +1507,11 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
@@ -1420,8 +1589,8 @@ packages:
     resolution: {integrity: sha512-afP4W205ONCuMoPBqcR6PSXnzX35KTcJygfJfcp+QY+uwm3p20p1YczWXhlICIzGMCxYBQcySEcOgsJcrkyobg==}
     engines: {node: '>=16'}
 
-  get-tsconfig@4.13.6:
-    resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
+  get-tsconfig@4.14.0:
+    resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
 
   glob@10.5.0:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
@@ -1655,13 +1824,13 @@ packages:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
 
-  playwright-core@1.58.2:
-    resolution: {integrity: sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==}
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.58.2:
-    resolution: {integrity: sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==}
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -2480,79 +2649,157 @@ snapshots:
   '@esbuild/aix-ppc64@0.27.4':
     optional: true
 
+  '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
   '@esbuild/android-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.7':
     optional: true
 
   '@esbuild/android-arm@0.27.4':
     optional: true
 
+  '@esbuild/android-arm@0.27.7':
+    optional: true
+
   '@esbuild/android-x64@0.27.4':
+    optional: true
+
+  '@esbuild/android-x64@0.27.7':
     optional: true
 
   '@esbuild/darwin-arm64@0.27.4':
     optional: true
 
+  '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
   '@esbuild/darwin-x64@0.27.4':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.7':
     optional: true
 
   '@esbuild/freebsd-arm64@0.27.4':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
   '@esbuild/freebsd-x64@0.27.4':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.7':
     optional: true
 
   '@esbuild/linux-arm64@0.27.4':
     optional: true
 
+  '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
   '@esbuild/linux-arm@0.27.4':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.7':
     optional: true
 
   '@esbuild/linux-ia32@0.27.4':
     optional: true
 
+  '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
   '@esbuild/linux-loong64@0.27.4':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.7':
     optional: true
 
   '@esbuild/linux-mips64el@0.27.4':
     optional: true
 
+  '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
   '@esbuild/linux-ppc64@0.27.4':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.7':
     optional: true
 
   '@esbuild/linux-riscv64@0.27.4':
     optional: true
 
+  '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
   '@esbuild/linux-s390x@0.27.4':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.7':
     optional: true
 
   '@esbuild/linux-x64@0.27.4':
     optional: true
 
+  '@esbuild/linux-x64@0.27.7':
+    optional: true
+
   '@esbuild/netbsd-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.7':
     optional: true
 
   '@esbuild/netbsd-x64@0.27.4':
     optional: true
 
+  '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.7':
     optional: true
 
   '@esbuild/openbsd-x64@0.27.4':
     optional: true
 
+  '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
   '@esbuild/openharmony-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.7':
     optional: true
 
   '@esbuild/sunos-x64@0.27.4':
     optional: true
 
+  '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
   '@esbuild/win32-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.7':
     optional: true
 
   '@esbuild/win32-ia32@0.27.4':
     optional: true
 
+  '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
   '@esbuild/win32-x64@0.27.4':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.7':
     optional: true
 
   '@fastify/busboy@2.1.1': {}
@@ -2624,9 +2871,9 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
-  '@playwright/test@1.58.2':
+  '@playwright/test@1.60.0':
     dependencies:
-      playwright: 1.58.2
+      playwright: 1.60.0
 
   '@protobufjs/aspromise@1.1.2': {}
 
@@ -3449,6 +3696,36 @@ snapshots:
       '@esbuild/win32-ia32': 0.27.4
       '@esbuild/win32-x64': 0.27.4
 
+  esbuild@0.27.7:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
+    optional: true
+
   escalade@3.2.0: {}
 
   estree-walker@3.0.3:
@@ -3505,7 +3782,7 @@ snapshots:
 
   get-port@7.2.0: {}
 
-  get-tsconfig@4.13.6:
+  get-tsconfig@4.14.0:
     dependencies:
       resolve-pkg-maps: 1.0.0
     optional: true
@@ -3707,11 +3984,11 @@ snapshots:
 
   picomatch@4.0.3: {}
 
-  playwright-core@1.58.2: {}
+  playwright-core@1.60.0: {}
 
-  playwright@1.58.2:
+  playwright@1.60.0:
     dependencies:
-      playwright-core: 1.58.2
+      playwright-core: 1.60.0
     optionalDependencies:
       fsevents: 2.3.2
 
@@ -4051,8 +4328,8 @@ snapshots:
 
   tsx@4.21.0:
     dependencies:
-      esbuild: 0.27.4
-      get-tsconfig: 4.13.6
+      esbuild: 0.27.7
+      get-tsconfig: 4.14.0
     optionalDependencies:
       fsevents: 2.3.3
     optional: true

--- a/scripts/check-playwright-internals.js
+++ b/scripts/check-playwright-internals.js
@@ -17,6 +17,7 @@ const fs = require('fs');
 const req = createRequire(path.join(process.cwd(), 'package.json'));
 
 const version = req('@playwright/test/package.json').version;
+/** @type {string[]} */
 const passed = [];
 /** @type {{ name: string; error: string }[]} */
 const failed = [];
@@ -42,45 +43,108 @@ function assert(condition, detail) {
     if (!condition) throw new Error(detail);
 }
 
+const pwDir = path.dirname(req.resolve('playwright/package.json'));
+
+/**
+ * Loads the configLoader module from old (lib/common/configLoader.js) or new
+ * (lib/common/index.js .configLoader namespace) Playwright layouts.
+ * Result is cached — Node module cache handles re-require, but the namespace
+ * lookup only runs once so a missing namespace isn't reported twice.
+ */
+/** @type {any} */
+let _configLoaderModule;
+function loadConfigLoaderModule() {
+    if (_configLoaderModule) return _configLoaderModule;
+    const oldPath = path.join(pwDir, 'lib/common/configLoader.js');
+    if (fs.existsSync(oldPath)) return (_configLoaderModule = require(oldPath));
+    const m = require(path.join(pwDir, 'lib/common/index.js')).configLoader;
+    assert(m != null, 'configLoader namespace not found in lib/common/index.js');
+    return (_configLoaderModule = m);
+}
+
 // ── Check 1: playwright/lib/common/configLoader.loadConfig ───────────────────
+// Old Playwright: lib/common/configLoader.js  New 1.60+: lib/common/index.js configLoader namespace
 check('playwright/lib/common/configLoader.loadConfig', () => {
-    const m = req('playwright/lib/common/configLoader');
-    assert(typeof m.loadConfig === 'function', `loadConfig is ${typeof m.loadConfig} (expected function)`);
+    const m = loadConfigLoaderModule();
+    assert(typeof m.loadConfig === 'function', `loadConfig is ${typeof m?.loadConfig} (expected function)`);
 });
 
 // ── Check 2: playwright/lib/common/configLoader.resolveConfigLocation ────────
 check('playwright/lib/common/configLoader.resolveConfigLocation', () => {
-    const m = req('playwright/lib/common/configLoader');
+    const m = loadConfigLoaderModule();
     assert(
         typeof m.resolveConfigLocation === 'function',
-        `resolveConfigLocation is ${typeof m.resolveConfigLocation} (expected function)`,
+        `resolveConfigLocation is ${typeof m?.resolveConfigLocation} (expected function)`,
     );
 });
 
 // ── Check 3: playwright/lib/plugins.webServer ─────────────────────────────────
+// Old Playwright:   lib/plugins.js (single file)
+// Mid Playwright:   lib/plugins/index.js (directory)
+// New 1.60+:        lib/runner/index.js (consolidated)
 check('playwright/lib/plugins.webServer', () => {
-    const m = req('playwright/lib/plugins');
-    assert(typeof m.webServer === 'function', `webServer is ${typeof m.webServer} (expected function)`);
+    let m;
+    // require(lib/plugins) resolves both lib/plugins.js and lib/plugins/index.js
+    const pluginsPath = path.join(pwDir, 'lib/plugins');
+    if (fs.existsSync(pluginsPath + '.js') || fs.existsSync(pluginsPath)) {
+        m = require(pluginsPath);
+    } else {
+        m = require(path.join(pwDir, 'lib/runner/index.js'));
+    }
+    assert(typeof m.webServer === 'function', `webServer is ${typeof m?.webServer} (expected function)`);
 });
 
-// ── Check 4: playwright/lib/runner/loadUtils.loadGlobalHook ──────────────────
-check('playwright/lib/runner/loadUtils.loadGlobalHook', () => {
-    const pwDir = path.dirname(req.resolve('playwright/package.json'));
-    const m = require(path.join(pwDir, 'lib/runner/loadUtils.js'));
-    assert(typeof m.loadGlobalHook === 'function', `loadGlobalHook is ${typeof m.loadGlobalHook} (expected function)`);
+// ── Check 4: global hook loading mechanism ────────────────────────────────────
+// Old Playwright: lib/runner/loadUtils.js exports loadGlobalHook
+// Mid Playwright: loadGlobalHook moved to lib/runner/index.js
+// New 1.60+: loadGlobalHook removed; use transform.requireOrImport from lib/common/index.js
+check('global hook loading mechanism (loadGlobalHook or transform.requireOrImport)', () => {
+    // Old path: loadUtils.js exports loadGlobalHook directly
+    const loadUtilsPath = path.join(pwDir, 'lib/runner/loadUtils.js');
+    if (fs.existsSync(loadUtilsPath)) {
+        const m = require(loadUtilsPath);
+        assert(
+            typeof m.loadGlobalHook === 'function',
+            `loadGlobalHook is ${typeof m?.loadGlobalHook} in lib/runner/loadUtils.js`,
+        );
+        return;
+    }
+    // Mid path: loadGlobalHook consolidated into lib/runner/index.js
+    const runnerIndexPath = path.join(pwDir, 'lib/runner/index.js');
+    if (fs.existsSync(runnerIndexPath)) {
+        const m = require(runnerIndexPath);
+        if (typeof m.loadGlobalHook === 'function') return;
+    }
+    // New 1.60+ path: use transform.requireOrImport from lib/common/index.js
+    const commonPath = path.join(pwDir, 'lib/common/index.js');
+    assert(
+        fs.existsSync(commonPath),
+        `No loadGlobalHook found and lib/common/index.js missing in playwright package`,
+    );
+    const m = require(commonPath);
+    assert(
+        typeof m.transform?.requireOrImport === 'function',
+        `loadGlobalHook absent from loadUtils.js/runner/index.js and transform.requireOrImport not found in lib/common/index.js`,
+    );
 });
 
 // ── Check 5: Suite._parallelMode ─────────────────────────────────────────────
 // _parallelMode is an instance property set in the Suite constructor.
-// We load the Suite class by its absolute path to bypass package exports restrictions,
-// then instantiate it and verify the property is present on the instance — exactly
-// mirroring how run-builder.ts uses it: `(suite as SuiteInternal)._parallelMode`.
+// Old Playwright: lib/common/test.js  New 1.60+: lib/common/index.js under test namespace
+// Mirrors how run-builder.ts uses it: `(suite as SuiteInternal)._parallelMode`.
 check('Suite._parallelMode', () => {
-    const pwDir = path.dirname(req.resolve('playwright/package.json'));
-    const testJsPath = path.join(pwDir, 'lib/common/test.js');
-    assert(fs.existsSync(testJsPath), `playwright/lib/common/test.js not found at ${testJsPath}`);
-    const { Suite } = req(testJsPath);
-    assert(typeof Suite === 'function', `Suite is not a class in playwright/lib/common/test.js`);
+    let Suite;
+    const oldPath = path.join(pwDir, 'lib/common/test.js');
+    if (fs.existsSync(oldPath)) {
+        ({ Suite } = require(oldPath));
+        assert(typeof Suite === 'function', `Suite is not a class in lib/common/test.js`);
+    } else {
+        const newPath = path.join(pwDir, 'lib/common/index.js');
+        assert(fs.existsSync(newPath), `playwright/lib/common/index.js not found at ${newPath}`);
+        const m = require(newPath);
+        assert(m.test && typeof m.test.Suite === 'function', `Suite not found in lib/common/index.js test namespace`);
+        ({ Suite } = m.test);
+    }
     const instance = new Suite('', 'suite');
     assert('_parallelMode' in instance, `Suite instance has no _parallelMode property`);
 });
@@ -91,7 +155,7 @@ console.log(`PLAYWRIGHT VERSION: ${version}\n`);
 if (failed.length > 0) {
     console.log('FAILED CHECKS:');
     for (const { name, error } of failed) {
-        console.log(`  \u274c ${name}`);
+        console.log(`  ❌ ${name}`);
         console.log(`     ${error}`);
     }
     console.log('');
@@ -100,7 +164,7 @@ if (failed.length > 0) {
 if (passed.length > 0) {
     console.log('PASSED CHECKS:');
     for (const name of passed) {
-        console.log(`  \u2705 ${name}`);
+        console.log(`  ✅ ${name}`);
     }
 }
 

--- a/tests/__snapshots__/test-report-project.report.snap
+++ b/tests/__snapshots__/test-report-project.report.snap
@@ -48,7 +48,6 @@
             "width": 1920
           },
           "trace": "on-first-retry",
-          "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.7632.6 Safari/537.36",
           "viewport": {
             "height": 720,
             "width": 1280
@@ -73,7 +72,6 @@
             "width": 1920
           },
           "trace": "on-first-retry",
-          "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:146.0.1) Gecko/20100101 Firefox/146.0.1",
           "viewport": {
             "height": 720,
             "width": 1280

--- a/tests/__snapshots__/test-report-test.report.snap
+++ b/tests/__snapshots__/test-report-test.report.snap
@@ -48,7 +48,6 @@
             "width": 1920
           },
           "trace": "on-first-retry",
-          "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.7632.6 Safari/537.36",
           "viewport": {
             "height": 720,
             "width": 1280
@@ -73,7 +72,6 @@
             "width": 1920
           },
           "trace": "on-first-retry",
-          "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:146.0.1) Gecko/20100101 Firefox/146.0.1",
           "viewport": {
             "height": 720,
             "width": 1280

--- a/tests/utils/test-storage.ts
+++ b/tests/utils/test-storage.ts
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, assert } from 'vitest';
 import { spawnAsync } from '../../packages/core/src/helpers/spawn.js';
 import { createRequire } from 'node:module';
 import { dirname, join } from 'node:path';
@@ -49,6 +49,9 @@ export async function testStorage(storageOptions: string[], reportsFolder: strin
             }),
         ),
     );
+    if (shardResults.some(({ stderr }) => stderr.toLocaleLowerCase().includes('error'))) {
+        assert.fail(`Run command failed. Errors: ${shardResults.map(({ stderr }) => stderr).join('\n')}`);
+    }
     const setupMarker = readFileSync(join(globalMarkerFolder, globalSetupMarkerFile), 'utf-8');
     const teardownMarker = readFileSync(join(globalMarkerFolder, globalTeardownMarkerFile), 'utf-8');
     // global setup and teardown + deps should be executed once per shard, so the marker files should contain the number of shards * 2
@@ -116,7 +119,7 @@ function clearReportForSnapshot(report: TestRunReport) {
                 .map((test) => ({ ...test, duration: 0, averageDuration: 0, lastSuccessfulRunTimestamp: 0, fails: 0 }))
                 .sort((a, b) => a.title.localeCompare(b.title)),
         }),
-        null,
+        (key, value) => (key === 'userAgent' ? undefined : value),
         2,
     );
 }


### PR DESCRIPTION
Playwright 1.60 consolidated lib/common/configLoader.js and lib/common/test.js into lib/common/index.js, and removed loadGlobalHook in favor of transform.requireOrImport. Add multi-path fallback resolution in playwright-config.ts and update check-playwright-internals.js accordingly.