### PR TITLE
feat: support parameterized tests by matching on grep instead of file + location

### DIFF
--- a/e2e/duration-simulation/failed.spec.ts
+++ b/e2e/duration-simulation/failed.spec.ts
@@ -1,8 +1,16 @@
 import { test, expect } from '@playwright/test';
 import { openTestPage, wait } from '../test-utils';
 
-test('should failing', { tag: '@duration-simulation' }, async ({ page }, { repeatEachIndex }) => {
+test('should failing', { tag: '@duration-simulation' }, async ({ page }) => {
     await openTestPage(page);
     await wait(1000);
-    expect(true).toBe(false);
+    expect(false).toBeTruthy();
+});
+
+test('should failing for firefox', { tag: '@duration-simulation' }, async ({ page, browserName }) => {
+    await openTestPage(page);
+    await wait(1000);
+    if (browserName === 'firefox') {
+        expect(false).toBeTruthy();
+    }
 });

--- a/e2e/duration-simulation/parametrized-case.spec.ts
+++ b/e2e/duration-simulation/parametrized-case.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from '@playwright/test';
+import { openTestPage, wait } from '../test-utils';
+
+const scenarios = [
+    { name: 'first', value: 1 },
+    { name: 'second', value: 0 },
+    { name: 'third', value: 2 },
+];
+
+for (const scenario of scenarios) {
+    test(`runs ${scenario.name} case`, { tag: '@duration-simulation' }, async ({ page }) => {
+        await openTestPage(page);
+        await wait(1000);
+        expect(scenario.value).toBeGreaterThan(0);
+    });
+}

--- a/e2e/test-simulation/parametrized-case.spec.ts
+++ b/e2e/test-simulation/parametrized-case.spec.ts
@@ -1,0 +1,15 @@
+import { test, expect } from '@playwright/test';
+import { openTestPage } from '../test-utils';
+
+const scenarios = [
+    { name: 'first', value: 1 },
+    { name: 'second', value: 0 },
+    { name: 'third', value: 2 },
+];
+
+for (const scenario of scenarios) {
+    test(`runs ${scenario.name} case`, { tag: '@test-simulation' }, async ({ page }) => {
+        await openTestPage(page);
+        expect(scenario.value).toBeGreaterThan(0);
+    });
+}

--- a/packages/core/src/adapters/base-adapter.ts
+++ b/packages/core/src/adapters/base-adapter.ts
@@ -35,9 +35,9 @@ export abstract class BaseAdapter implements Adapter {
 
     protected buildReport(test: TestItem, item: HistoryItem, newEma: number, history: HistoryItem[]): TestReport {
         return {
-            file: test.file,
-            position: test.position,
-            projects: test.projects,
+            file: test.meta.file,
+            position: test.meta.position,
+            projects: test.meta.projects,
             status: item.status,
             duration: item.duration,
             averageDuration: newEma,

--- a/packages/core/src/adapters/base-test-run-creator.ts
+++ b/packages/core/src/adapters/base-test-run-creator.ts
@@ -54,23 +54,27 @@ export abstract class BaseTestRunCreator implements TestRunCreator {
     }
     private transformTestRunToItems(run: ReporterTestRun, options: BaseOptions): TestItem[] {
         const tests = Object.entries(run)
-            .flatMap(([file, tests]) =>
-                Object.entries(tests).flatMap(([position, { timeout, projects, title, annotations, children }]) => {
-                    const baseItem = { file, position, timeout };
-                    if (options.grouping === 'test') {
-                        return {
-                            ...baseItem,
-                            testId: getTestId({ file, title, annotations }),
-                            projects,
-                            children: children?.map((child) => getTestId({ file, title: child, annotations })),
+            .flatMap(([file, positions]) =>
+                Object.entries(positions).flatMap(([position, titles]) => {
+                    const titleEntries = Object.entries(titles);
+                    return titleEntries.flatMap(([title, { timeout, projects, annotations, children }]) => {
+                        const baseItem = {
+                            timeout,
+                            meta: { title, children, file, position, annotations },
                         };
-                    }
-                    return projects.flatMap((project) => ({
-                        ...baseItem,
-                        testId: getTestId({ project, file, title, annotations }),
-                        projects: [project],
-                        children: children?.map((child) => getTestId({ project, file, title: child, annotations })),
-                    }));
+                        if (options.grouping === 'test') {
+                            return {
+                                ...baseItem,
+                                testId: getTestId({ file, title, annotations }),
+                                meta: { ...baseItem.meta, projects },
+                            };
+                        }
+                        return projects.flatMap((project) => ({
+                            ...baseItem,
+                            testId: getTestId({ project, file, title, annotations }),
+                            meta: { ...baseItem.meta, projects: [project] },
+                        }));
+                    });
                 }),
             )
             .map((test) => ({ ...test, order: 0, ema: 0 }));
@@ -117,10 +121,10 @@ export abstract class BaseTestRunCreator implements TestRunCreator {
 
         return tests
             .map((test) => {
-                const filtered = test.projects.filter((p) => !infraProjects.has(p));
+                const filtered = test.meta.projects.filter((p) => !infraProjects.has(p));
                 if (filtered.length === 0) return null;
-                if (filtered.length === test.projects.length) return test;
-                return { ...test, projects: filtered };
+                if (filtered.length === test.meta.projects.length) return test;
+                return { ...test, meta: { ...test.meta, projects: filtered } };
             })
             .filter((test): test is TestItem => test !== null);
     }
@@ -132,7 +136,7 @@ export abstract class BaseTestRunCreator implements TestRunCreator {
                 const existing = existingIds.get(test.testId)!;
                 throw new Error(
                     [
-                        `Test ${existing.file}:${existing.position} has the same ID as ${test.file}:${test.position}.`,
+                        `Test ${existing.meta.file}:${existing.meta.position} has the same ID as ${test.meta.file}:${test.meta.position}.`,
                         'Please make sure that each test has a unique ID annotation.',
                         'If no ID annotation is provided, the `{file} > {title}` will be taken as ID.',
                         'Or file name in case test is serial at the top level.',

--- a/packages/core/src/batch/auto-batch-handler.ts
+++ b/packages/core/src/batch/auto-batch-handler.ts
@@ -19,7 +19,7 @@ export class AutoBatchHandler extends BaseBatchHandler implements BatchHandler {
                 if (accumulated >= budget || batch.length >= cap) break;
             }
 
-            const test = await this.getNextTest(config, batch[0]?.projects[0]);
+            const test = await this.getNextTest(config, batch[0]?.meta.projects[0]);
             if (!test) break;
 
             batch.push(test);

--- a/packages/core/src/batch/count-batch-handler.ts
+++ b/packages/core/src/batch/count-batch-handler.ts
@@ -10,7 +10,7 @@ export class CountBatchHandler extends BaseBatchHandler implements BatchHandler 
         const batch: TestItem[] = [];
         let test: TestItem | undefined;
         for (let i = 0; i < config.options.batchTarget!; i++) {
-            test = await this.getNextTest(config, test?.projects[0]);
+            test = await this.getNextTest(config, test?.meta.projects[0]);
             if (!test) break;
             batch.push(test);
         }

--- a/packages/core/src/batch/time-batch-handler.ts
+++ b/packages/core/src/batch/time-batch-handler.ts
@@ -14,7 +14,7 @@ export class TimeBatchHandler extends BaseBatchHandler implements BatchHandler {
         const threshold = budget * THRESHOLD;
         let test: TestItem | undefined;
         while (budget + threshold > (test?.ema ?? 0)) {
-            test = await this.getNextTest(config, test?.projects[0]);
+            test = await this.getNextTest(config, test?.meta.projects[0]);
             if (!test) break;
             batch.push(test);
             budget -= test.ema;

--- a/packages/core/src/helpers/regex.ts
+++ b/packages/core/src/helpers/regex.ts
@@ -1,0 +1,7 @@
+export function escapeRegex(str: string): string {
+    return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+export function makeGrepPattern(file: string, title: string): string {
+    return `(?:^| )(?:\\S*/)?${escapeRegex(file)} (?:.*\\s)?${escapeRegex(title)}(?: @\\S+)*$`;
+}

--- a/packages/core/src/playwright-tools/run-builder.ts
+++ b/packages/core/src/playwright-tools/run-builder.ts
@@ -52,35 +52,52 @@ export class RunBuilder {
     private tryParseEntry(entry: TestCase | Suite) {
         const [_, project, file] = entry.titlePath();
         if (!file) return false;
-        const fileTests = this.getFileTests(file);
         const position = entry.location ? `${entry.location.line}:${entry.location.column}` : '0:0';
-        if (fileTests[position]) {
-            if (!fileTests[position].projects.includes(project)) {
-                fileTests[position].projects.push(project);
+
+        if (entry.type === 'test') {
+            const positionMap = this.getPositionMap(file, position);
+            if (positionMap[entry.title]) {
+                if (!positionMap[entry.title].projects.includes(project)) {
+                    positionMap[entry.title].projects.push(project);
+                }
+            } else {
+                positionMap[entry.title] = {
+                    timeout: getEntryTimeout(entry),
+                    projects: [project],
+                    annotations: this.getAnnotations(entry),
+                };
             }
             return true;
         }
-        if (entry.type === 'test' || isSuiteSerial(entry as Suite)) {
-            const children = entry.type === 'test' ? undefined : entry.allTests().map((test) => test.title);
-            fileTests[position] = {
-                timeout: getEntryTimeout(entry),
-                projects: [project],
-                annotations: this.getAnnotations(entry),
-                title: entry.title,
-                children: children,
-            };
+
+        if (isSuiteSerial(entry as Suite)) {
+            const positionMap = this.getPositionMap(file, position);
+            if (positionMap[entry.title]) {
+                if (!positionMap[entry.title].projects.includes(project)) {
+                    positionMap[entry.title].projects.push(project);
+                }
+            } else {
+                positionMap[entry.title] = {
+                    timeout: getEntryTimeout(entry),
+                    projects: [project],
+                    annotations: this.getAnnotations(entry),
+                    children: (entry as Suite).allTests().map((test) => test.title),
+                };
+            }
             return true;
         }
+
         return false;
     }
 
     private getAnnotations(entry: TestCase | Suite) {
-        const annotations = entry.type === 'test' ? entry.annotations : entry.allTests()[0]?.annotations;
+        const annotations = entry.type === 'test' ? entry.annotations : (entry as Suite).allTests()[0]?.annotations;
         return annotations?.map(({ type, description }) => ({ type, description }));
     }
 
-    private getFileTests(file: string) {
+    private getPositionMap(file: string, position: string) {
         if (!this.testRun[file]) this.testRun[file] = {};
-        return this.testRun[file];
+        if (!this.testRun[file][position]) this.testRun[file][position] = {};
+        return this.testRun[file][position];
     }
 }

--- a/packages/core/src/runner/test-event-handler.ts
+++ b/packages/core/src/runner/test-event-handler.ts
@@ -6,6 +6,7 @@ import { TestExecutionReporter } from './test-execution-reporter.js';
 import type { Adapter } from '../adapters/adapter.js';
 import { SYMBOLS } from '../symbols.js';
 import { Project, TestStatus } from '../types/test-info.js';
+import { getTestId } from '../helpers/get-test-id.js';
 
 type HandlerResult = {
     onData: (data: any, isError: boolean) => void;
@@ -90,7 +91,11 @@ export class PlaywrightTestEventHandler implements TestEventHandler {
         const {
             test: { testId: eventTestId },
         } = event;
-        const test = this.testMapping.get(eventTestId)!;
+        const test = this.testMapping.get(eventTestId);
+        if (!test) {
+            this.reporter.error(`Test with id ${eventTestId} not found.`);
+            return;
+        }
         const { childId, displayName } = this.extractChildData(event);
         if (!this.testResolvers.has(test.testId)) {
             this.reporter.addGroup(this.batchName, test, this.createTestPromise(test.testId));
@@ -108,7 +113,8 @@ export class PlaywrightTestEventHandler implements TestEventHandler {
             result: { duration, status, retry, error },
             project,
         } = event;
-        const test = this.testMapping.get(eventTestId)!;
+        const test = this.testMapping.get(eventTestId);
+        if (!test) return;
         const { childId } = this.extractChildData(event);
 
         if (ok || retries === retry) {
@@ -155,14 +161,31 @@ export class PlaywrightTestEventHandler implements TestEventHandler {
         }
         for (const test of tests) {
             this.testMapping.set(test.testId, test);
-            for (const childId of test.children ?? []) {
-                this.testMapping.set(childId, test);
+            for (const child of test.meta.children ?? []) {
+                const baseTestIdParams = {
+                    file: test.meta.file,
+                    title: child,
+                    annotations: test.meta.annotations,
+                };
+                if (config.options.grouping === Grouping.Test) {
+                    this.testMapping.set(getTestId(baseTestIdParams), test);
+                } else {
+                    for (const project of test.meta.projects) {
+                        this.testMapping.set(
+                            getTestId({
+                                ...baseTestIdParams,
+                                project,
+                            }),
+                            test,
+                        );
+                    }
+                }
             }
-            for (const project of test.projects) {
+            for (const project of test.meta.projects) {
                 const value = this.testCounts.get(test.testId) ?? 0;
                 this.testCounts.set(
                     test.testId,
-                    value + (test.children?.length ?? 1) * this.projects.get(project)!.repeatEach,
+                    value + (test.meta.children?.length ?? 1) * this.projects.get(project)!.repeatEach,
                 );
             }
             this.reporter.addGroup(batchName, test, this.createTestPromise(test.testId));

--- a/packages/core/src/runner/test-runner.ts
+++ b/packages/core/src/runner/test-runner.ts
@@ -16,6 +16,7 @@ import type { TestEventHandlerFactory } from './test-event-handler.js';
 import { cliVersion } from '../commands/version.js';
 import { registerOnExit } from '../helpers/register-on-exit.js';
 import { PlaywrightConfigLoader } from '../helpers/playwright-config.js';
+import { makeGrepPattern } from '../helpers/regex.js';
 
 @injectable()
 export class TestRunner {
@@ -132,10 +133,16 @@ export class TestRunner {
         const args = [];
         const projects = new Set<string>();
         for (const test of tests) {
-            args.push(`${test.file.replace(/\\/g, '/')}:${test.position}`);
-            for (const project of test.projects) {
+            for (const project of test.meta.projects) {
                 projects.add(project);
             }
+        }
+        const greps = tests.flatMap(({ meta: { file, title, children } }) => [
+            makeGrepPattern(file, title),
+            ...(children?.map((child) => makeGrepPattern(file, child)) ?? []),
+        ]);
+        if (greps.length > 0) {
+            args.push('--grep', greps.join('|'));
         }
         args.push(...config.args);
         args.push('--workers', '1');

--- a/packages/core/src/types/adapters.ts
+++ b/packages/core/src/types/adapters.ts
@@ -46,13 +46,17 @@ export interface BaseOptions {
 
 export interface TestItem {
     testId: string;
-    file: string;
-    position: string;
-    projects: string[];
     order: number;
     timeout: number;
-    children?: string[];
     ema: number;
+    meta: {
+        title: string;
+        children?: string[];
+        projects: string[];
+        file: string;
+        position: string;
+        annotations: TestDetailsAnnotation[];
+    };
 }
 
 export interface ResultTestParams {

--- a/packages/core/src/types/test-info.ts
+++ b/packages/core/src/types/test-info.ts
@@ -24,11 +24,12 @@ export interface ReporterTestRunInfo {
 export interface ReporterTestRun {
     [file: string]: {
         [position: string]: {
-            timeout: number;
-            projects: string[];
-            title: string;
-            annotations: TestDetailsAnnotation[];
-            children?: string[];
+            [title: string]: {
+                timeout: number;
+                projects: string[];
+                annotations: TestDetailsAnnotation[];
+                children?: string[];
+            };
         };
     };
 }

--- a/packages/dynamo-db/src/constants.ts
+++ b/packages/dynamo-db/src/constants.ts
@@ -34,4 +34,5 @@ export enum Fields {
     Created = 'cr',
     Children = 'chl',
     Shards = 'sh',
+    Meta = 'm',
 }

--- a/packages/dynamo-db/src/dynamo-db-adapter.ts
+++ b/packages/dynamo-db/src/dynamo-db-adapter.ts
@@ -46,9 +46,9 @@ export class DynamoDbAdapter extends BaseAdapter {
             tests: tests.map((test) => {
                 const report = test[Fields.Report];
                 return {
-                    file: test[Fields.File],
-                    projects: test[Fields.Projects] ?? [test[Fields.Project]!],
-                    position: `${test[Fields.Line]}:${test[Fields.Character]}`,
+                    file: test[Fields.Meta].file,
+                    projects: test[Fields.Meta].projects,
+                    position: test[Fields.Meta].position,
                     status: idToStatus(test[Fields.Order]),
                     title: test[Fields.TestId],
                     fails: report?.[Fields.Fails] ?? 0,

--- a/packages/dynamo-db/src/helpers.ts
+++ b/packages/dynamo-db/src/helpers.ts
@@ -5,46 +5,33 @@ import { TestInfoItem, TestItemDb, TestRunDb } from './types.js';
 export function mapTestItemToDb(
     runId: string,
     ttl: number,
-    { position, order, file, projects, timeout, ema, children, testId }: TestItem,
+    { order, timeout, ema, testId, meta }: TestItem,
     status: StatusOffset = StatusOffset.Pending,
 ): TestItemDb {
-    const [line, character] = position.split(':');
     return {
         [Fields.Id]: runId,
         [Fields.Order]: (order % OFFSET_STEP) + status,
         [Fields.TestId]: testId,
-        [Fields.Line]: line,
-        [Fields.Character]: character,
-        [Fields.File]: file,
-        [Fields.Projects]: projects,
         [Fields.Timeout]: timeout,
         [Fields.EMA]: ema,
         [Fields.Ttl]: ttl,
-        [Fields.Children]: children,
+        [Fields.Meta]: meta,
     };
 }
 
 export function mapDbToTestItem({
     [Fields.TestId]: testId,
     [Fields.Order]: order,
-    [Fields.Line]: line,
-    [Fields.Character]: character,
-    [Fields.File]: file,
-    [Fields.Project]: project,
-    [Fields.Projects]: projects,
     [Fields.Timeout]: timeout,
     [Fields.EMA]: ema,
-    [Fields.Children]: children,
+    [Fields.Meta]: meta,
 }: TestItemDb): TestItem {
     return {
         testId,
-        position: `${line}:${character}`,
-        file,
-        projects: projects ?? [project!],
         order,
         timeout,
         ema,
-        children,
+        meta,
     };
 }
 

--- a/packages/dynamo-db/src/types.ts
+++ b/packages/dynamo-db/src/types.ts
@@ -1,20 +1,15 @@
-import { ResultTestParams, TestRunConfig, TestShard } from '@playwright-orchestrator/core';
+import { ResultTestParams, TestRunConfig, TestShard, TestItem } from '@playwright-orchestrator/core';
 import { Fields } from './constants.js';
 
 export interface TestItemDb {
     [Fields.Id]: string;
     [Fields.Order]: number;
     [Fields.TestId]: string;
-    [Fields.Line]: string;
-    [Fields.Character]: string;
-    [Fields.File]: string;
-    [Fields.Project]?: string;
-    [Fields.Projects]: string[];
     [Fields.Timeout]: number;
     [Fields.EMA]: number;
     [Fields.Ttl]: number;
     [Fields.Report]?: TestReport;
-    [Fields.Children]?: string[];
+    [Fields.Meta]: TestItem['meta'];
 }
 
 export interface TestReport {

--- a/packages/file/src/file-adapter.ts
+++ b/packages/file/src/file-adapter.ts
@@ -24,7 +24,7 @@ export class FileAdapter extends BaseAdapter {
             runId,
             config,
             shards,
-            tests: tests.map(({ file, status, projects, position, report }) => ({
+            tests: tests.map(({ status, report, meta: { file, position, projects } }) => ({
                 averageDuration: report.ema,
                 duration: report.duration,
                 fails: report.fails,

--- a/packages/file/src/file-shard-handler.ts
+++ b/packages/file/src/file-shard-handler.ts
@@ -38,15 +38,12 @@ export class FileShardHandler implements ShardHandler {
                     ) as ResultTestItem[];
                     const failed: TestItem[] = results
                         .filter((r) => r.status === TestStatus.Failed)
-                        .map(({ file, testId, order, position, projects, timeout, children, ema }) => ({
-                            file,
+                        .map(({ testId, order, timeout, ema, meta }) => ({
                             testId,
                             order,
-                            position,
-                            projects,
                             timeout,
-                            children,
                             ema,
+                            meta,
                         }));
 
                     const rest = results.filter((r) => r.status !== TestStatus.Failed);
@@ -95,7 +92,7 @@ export class FileShardHandler implements ShardHandler {
         const release = await lock(file, { retries: 100 });
         try {
             const tests = JSON.parse(await readFile(file, 'utf-8')) as TestItem[];
-            const index = project ? tests.findLastIndex((t) => t.projects.includes(project)) : tests.length - 1;
+            const index = project ? tests.findLastIndex((t) => t.meta.projects.includes(project)) : tests.length - 1;
             if (index === -1) return undefined;
             const [test] = tests.splice(index, 1);
             await writeFile(file, JSON.stringify(tests, null, 2));

--- a/packages/mongo/src/mongo-db-adapter.ts
+++ b/packages/mongo/src/mongo-db-adapter.ts
@@ -44,8 +44,7 @@ export class MongoDbAdapter extends BaseAdapter {
             runId,
             config,
             shards,
-            tests: tests.map(({ file, line, column, status, report, projects }) => {
-                const position = `${line}:${column}`;
+            tests: tests.map(({ status, report, meta: { file, position, projects } }) => {
                 const { duration, fails, title, lastSuccessfulRun, ema } = report!;
                 return {
                     file,

--- a/packages/mongo/src/mongo-shard-handler.ts
+++ b/packages/mongo/src/mongo-shard-handler.ts
@@ -36,7 +36,7 @@ export class MongoShardHandler implements ShardHandler {
 
     private async claimNextTest(runId: string, project?: string): Promise<TestItem | undefined> {
         const query = project
-            ? { ...this.generateTestIdQuery(runId, TestStatus.Ready), projects: project }
+            ? { ...this.generateTestIdQuery(runId, TestStatus.Ready), 'meta.projects': project }
             : this.generateTestIdQuery(runId, TestStatus.Ready);
         const result = await this.tests.findOneAndUpdate(query, {
             $set: { updated: new Date(), status: TestStatus.Ongoing },
@@ -47,9 +47,9 @@ export class MongoShardHandler implements ShardHandler {
             { _id: generateRunId(runId) },
             { $inc: { 'config.remainingCount': -1, 'config.remainingTime': -effectiveEma } },
         );
-        const { file, line, column, projects, timeout, ema, children, testId } = result;
+        const { timeout, ema, testId, meta } = result;
         const { order } = parseTestId(result._id);
-        return { file, position: `${line}:${column}`, projects, timeout, ema, order, children, testId };
+        return { timeout, ema, order, testId, meta };
     }
 
     async startShard(): Promise<TestRunConfig> {
@@ -81,7 +81,10 @@ export class MongoShardHandler implements ShardHandler {
             });
             if (statusBefore === RunStatus.Finished) {
                 const [agg] = await this.tests
-                    .aggregate<{ count: number; totalEma: number }>([
+                    .aggregate<{
+                        count: number;
+                        totalEma: number;
+                    }>([
                         { $match: this.generateTestIdQuery(runId, TestStatus.Ready) },
                         { $group: { _id: null, count: { $sum: 1 }, totalEma: { $sum: '$ema' } } },
                     ])

--- a/packages/mongo/src/mongo-test-run-creator.ts
+++ b/packages/mongo/src/mongo-test-run-creator.ts
@@ -63,20 +63,15 @@ export class MongoTestRunCreator extends BaseTestRunCreator {
         await this.connection.db.collection(this.runsCollection).insertOne(run as any);
         if (tests.length === 0) return;
         await (this.connection.db.collection(this.testsCollection) as any).insertMany(
-            tests.map(({ file, order, position, projects, timeout, ema, children, testId }) => {
-                const [line, column] = position.split(':').map(Number);
+            tests.map(({ order, timeout, ema, testId, meta }) => {
                 return {
                     _id: generateTestId(runId, order),
                     testId,
-                    file,
-                    projects,
                     timeout,
                     ema,
-                    line,
-                    column,
                     status: TestStatus.Ready,
                     updated: now,
-                    children,
+                    meta,
                     ...(this.debug ? { runId, order } : {}),
                 };
             }),

--- a/packages/mongo/src/types.ts
+++ b/packages/mongo/src/types.ts
@@ -9,12 +9,10 @@ export interface TestRunDocument extends Document {
     updated: Date;
 }
 
-export interface TestDocument extends Document, Omit<TestItem, 'order' | 'position'> {
+export interface TestDocument extends Document, Omit<TestItem, 'order'> {
     _id: Binary;
     runId?: string;
     order?: number;
-    line: number;
-    column: number;
     status: TestStatus;
     updated: Date;
     report?: TestItemReport;

--- a/packages/mysql/src/mysql-adapter.ts
+++ b/packages/mysql/src/mysql-adapter.ts
@@ -1,4 +1,11 @@
-import { BaseAdapter, TestStatus, TestRunReport, SaveTestResultParams, TestShard } from '@playwright-orchestrator/core';
+import {
+    BaseAdapter,
+    TestStatus,
+    TestRunReport,
+    SaveTestResultParams,
+    TestShard,
+    TestItem,
+} from '@playwright-orchestrator/core';
 import { injectable, inject } from 'inversify';
 import type { CreateArgs } from './create-args.js';
 import { MySQLPool } from './mysql-pool.js';
@@ -7,11 +14,8 @@ import { MYSQL_CONFIG, MYSQL_POOL } from './symbols.js';
 
 interface Test extends RowDataPacket {
     order_num: number;
-    file: string;
-    line: number;
-    pos: number;
-    project: string;
     timeout: number;
+    meta: TestItem['meta'];
     report?: {
         title: string;
         status: TestStatus;
@@ -79,13 +83,13 @@ export class MySQLAdapter extends BaseAdapter {
             runId,
             config,
             shards,
-            tests: tests.map(({ file, projects, report, line, pos }) => {
+            tests: tests.map(({ report, meta: { file, position, projects } }) => {
                 return {
                     averageDuration: report?.ema ?? 0,
                     file,
                     duration: report?.duration ?? 0,
                     fails: report?.fails ?? 0,
-                    position: `${line}:${pos}`,
+                    position,
                     projects,
                     status: report?.status ?? TestStatus.Ready,
                     title: report?.title ?? '',

--- a/packages/mysql/src/mysql-initializer.ts
+++ b/packages/mysql/src/mysql-initializer.ts
@@ -67,11 +67,30 @@ export class MySQLInitializer implements Initializer {
         await this.addColumnIfMissing(testsTable, 'test_id', 'TEXT', false, "''");
         await this.addColumnIfMissing(configTable, 'shards', 'JSON', false, "'{}'");
         await this.migrateProjectsToJson(testsTable);
+        await this.migrateTestItemsToMeta(testsTable);
+    }
+
+    private async migrateTestItemsToMeta(tableName: string): Promise<void> {
+        if (await this.columnExists(tableName, 'meta')) {
+            return;
+        }
+        await this.addColumnIfMissing(tableName, 'meta', 'JSON', false, "'{}'");
+        await this.mysqlPool.pool.query({
+            sql: `UPDATE ?? SET meta = JSON_OBJECT('file', file, 'projects', projects, 'position', CONCAT(line, ':', pos), 'children', IFNULL(children, JSON_ARRAY()), 'annotations', JSON_ARRAY(), 'title', test_id)`,
+            values: [tableName],
+        });
+        await this.mysqlPool.pool.query({
+            sql: `ALTER TABLE ?? DROP COLUMN file, DROP COLUMN projects, DROP COLUMN line, DROP COLUMN pos, DROP COLUMN children`,
+            values: [tableName],
+        });
     }
 
     private async migrateProjectsToJson(tableName: string): Promise<void> {
-        const hasProjectsColumn = await this.columnExists(tableName, 'projects');
-        if (hasProjectsColumn) return;
+        const [hasProjectsColumn, hasMetaColumn] = await Promise.all([
+            this.columnExists(tableName, 'projects'),
+            this.columnExists(tableName, 'meta'),
+        ]);
+        if (hasProjectsColumn || hasMetaColumn) return;
 
         await this.mysqlPool.pool.query({
             sql: `ALTER TABLE ?? ADD COLUMN projects JSON NULL;`,

--- a/packages/mysql/src/mysql-shard-handler.ts
+++ b/packages/mysql/src/mysql-shard-handler.ts
@@ -9,14 +9,10 @@ import { MYSQL_CONFIG, MYSQL_POOL } from './symbols.js';
 
 interface Test extends RowDataPacket {
     order_num: number;
-    file: string;
-    line: number;
-    pos: number;
-    project: string;
     timeout: number;
     ema: number;
-    children?: string[];
     test_id: string;
+    meta: TestItem['meta'];
 }
 
 interface Run extends RowDataPacket {
@@ -54,7 +50,7 @@ export class MySQLShardHandler implements ShardHandler {
     }
 
     private async claimNextTest(runId: string, project?: string): Promise<TestItem | undefined> {
-        const projectFilter = project ? `AND JSON_CONTAINS(projects, JSON_QUOTE(?))` : '';
+        const projectFilter = project ? `AND JSON_CONTAINS(JSON_EXTRACT(meta, '$.projects'), JSON_QUOTE(?))` : '';
         const filterParams = project ? [project] : [];
         const client = await this.pool.getConnection();
         try {
@@ -97,16 +93,13 @@ export class MySQLShardHandler implements ShardHandler {
             );
             await client.commit();
             if (result[3].length === 0) return undefined;
-            const { file, line, pos, projects, timeout, ema, order_num, children, test_id } = result[3][0];
+            const { timeout, ema, order_num, test_id, meta } = result[3][0];
             return {
-                file,
-                position: `${line}:${pos}`,
-                projects,
                 timeout,
                 ema,
                 order: order_num,
-                children,
                 testId: test_id,
+                meta,
             };
         } catch (e) {
             await client.rollback();
@@ -147,8 +140,12 @@ export class MySQLShardHandler implements ShardHandler {
                         ) WHERE id = UUID_TO_BIN(?)`,
                         values: [
                             this.configTable,
-                            this.testsTable, runId, TestStatus.Ready,
-                            this.testsTable, runId, TestStatus.Ready,
+                            this.testsTable,
+                            runId,
+                            TestStatus.Ready,
+                            this.testsTable,
+                            runId,
+                            TestStatus.Ready,
                             runId,
                         ],
                     });

--- a/packages/mysql/src/mysql-test-run-creator.ts
+++ b/packages/mysql/src/mysql-test-run-creator.ts
@@ -85,20 +85,8 @@ export class MySQLTestRunCreator extends BaseTestRunCreator {
     async saveRunData(runId: string, testRun: TestRun, tests: TestItem[]): Promise<void> {
         testRun.config.remainingCount = tests.length;
         testRun.config.remainingTime = tests.reduce((sum, t) => sum + t.ema, 0);
-        const testValues = tests.map(({ position, order, file, projects, timeout, ema, children, testId }) => {
-            const [line, character] = position.split(':');
-            return [
-                runId,
-                order,
-                file,
-                +line,
-                +character,
-                JSON.stringify(projects),
-                timeout,
-                ema,
-                children != null ? JSON.stringify(children) : null,
-                testId,
-            ];
+        const testValues = tests.map(({ order, timeout, ema, testId, meta }) => {
+            return [runId, order, timeout, ema, testId, JSON.stringify(meta)];
         });
 
         const statements: string[] = [
@@ -112,8 +100,8 @@ export class MySQLTestRunCreator extends BaseTestRunCreator {
         ];
         if (testValues.length) {
             statements.push(
-                `INSERT INTO ?? (run_id, order_num, file, line, pos, projects, timeout, ema, children, test_id) VALUES ${testValues
-                    .map(() => '(UUID_TO_BIN(?), ?, ?, ?, ?, ?, ?, ?, ?, ?)')
+                `INSERT INTO ?? (run_id, order_num, timeout, ema, test_id, meta) VALUES ${testValues
+                    .map(() => '(UUID_TO_BIN(?), ?, ?, ?, ?, ?)')
                     .join(', ')}`,
             );
             values.push(this.testsTable, ...testValues.flatMap((v) => v));

--- a/packages/pg/src/pg-adapter.ts
+++ b/packages/pg/src/pg-adapter.ts
@@ -45,13 +45,13 @@ export class PostgreSQLAdapter extends BaseAdapter {
             runId,
             config,
             shards,
-            tests: rows.map(({ file, projects, line, character, report }) => ({
+            tests: rows.map(({ report, meta: { file, projects, position } }) => ({
                 averageDuration: report?.ema ?? 0,
                 duration: report?.duration ?? 0,
                 status: report?.status ?? TestStatus.Ready,
                 fails: report?.fails ?? 0,
                 file,
-                position: `${line}:${character}`,
+                position,
                 projects,
                 title: report?.title,
                 lastSuccessfulRunTimestamp: report?.lastSuccessfulRun,

--- a/packages/pg/src/pg-initializer.ts
+++ b/packages/pg/src/pg-initializer.ts
@@ -54,6 +54,10 @@ export class PgInitializer implements Initializer {
                 SELECT 1
                 FROM information_schema.columns
                 WHERE table_name = ${pg.escapeLiteral(`${tableNamePrefix}_tests`)} AND column_name = 'projects'
+            ) AND NOT EXISTS (
+                SELECT 1
+                FROM information_schema.columns
+                WHERE table_name = ${pg.escapeLiteral(`${tableNamePrefix}_tests`)} AND column_name = 'meta'
             ) THEN
                 ALTER TABLE ${testsTable} ADD COLUMN projects JSONB NOT NULL DEFAULT '[]';
                 UPDATE ${testsTable} SET projects = jsonb_build_array(project) WHERE project IS NOT NULL;
@@ -61,7 +65,16 @@ export class PgInitializer implements Initializer {
                 ALTER TABLE ${testsTable} ALTER COLUMN projects DROP DEFAULT;
             END IF;
             END $$;
-            UPDATE ${testsTable} SET projects = '[]' WHERE projects IS NULL;
+            DO $$
+            BEGIN
+            IF EXISTS (
+                SELECT 1
+                FROM information_schema.columns
+                WHERE table_name = ${pg.escapeLiteral(`${tableNamePrefix}_tests`)} AND column_name = 'projects'
+            ) THEN
+                UPDATE ${testsTable} SET projects = '[]' WHERE projects IS NULL;
+            END IF;
+            END $$;
             CREATE INDEX IF NOT EXISTS status_idx ON ${testsTable}(status);
             CREATE TABLE IF NOT EXISTS ${testInfoTable} (
                 id SERIAL PRIMARY KEY,
@@ -78,7 +91,32 @@ export class PgInitializer implements Initializer {
                 test_info_id INT NOT NULL,
                 FOREIGN KEY (test_info_id) REFERENCES ${testInfoTable}(id)
             );
-            CREATE INDEX IF NOT EXISTS test_info_id_idx ON ${testInfoHistoryTable}(test_info_id);`,
+            CREATE INDEX IF NOT EXISTS test_info_id_idx ON ${testInfoHistoryTable}(test_info_id);
+            
+            DO $$
+            BEGIN
+            IF NOT EXISTS (
+                SELECT 1
+                FROM information_schema.columns
+                WHERE table_name = ${pg.escapeLiteral(`${tableNamePrefix}_tests`)} AND column_name = 'meta'
+            ) THEN
+                ALTER TABLE ${testsTable} ADD COLUMN meta JSONB NOT NULL DEFAULT '{}'::jsonb;
+                UPDATE ${testsTable} SET meta = jsonb_build_object(
+                    'file', file,
+                    'projects', projects,
+                    'position', CONCAT(line, ':', character),
+                    'children', children,
+                    'annotations', '[]'::jsonb,
+                    'title', test_id
+                );
+                ALTER TABLE ${testsTable} DROP COLUMN IF EXISTS file;
+                ALTER TABLE ${testsTable} DROP COLUMN IF EXISTS line;
+                ALTER TABLE ${testsTable} DROP COLUMN IF EXISTS character;
+                ALTER TABLE ${testsTable} DROP COLUMN IF EXISTS children;
+                ALTER TABLE ${testsTable} DROP COLUMN IF EXISTS projects;
+            END IF;
+            END $$;
+            `,
         );
     }
 }

--- a/packages/pg/src/pg-shard-handler.ts
+++ b/packages/pg/src/pg-shard-handler.ts
@@ -33,7 +33,7 @@ export class PgShardHandler implements ShardHandler {
     }
 
     private async claimNextTest(runId: string, project?: string): Promise<TestItem | undefined> {
-        const projectFilter = project ? `AND projects @> to_jsonb(ARRAY[$4]::text[])` : '';
+        const projectFilter = project ? `AND meta->'projects' @> to_jsonb(ARRAY[$4]::text[])` : '';
         const values = project
             ? [runId, TestStatus.Ready, TestStatus.Ongoing, project]
             : [runId, TestStatus.Ready, TestStatus.Ongoing];
@@ -59,7 +59,7 @@ export class PgShardHandler implements ShardHandler {
                 await client.query('COMMIT');
                 return undefined;
             }
-            const { file, line, character, projects, timeout, ema, order_num, children, test_id } = result.rows[0];
+            const { timeout, ema, order_num, test_id, meta } = result.rows[0];
             await client.query({
                 text: `UPDATE ${this.configTable}
                 SET config = jsonb_set(jsonb_set(config,
@@ -70,14 +70,11 @@ export class PgShardHandler implements ShardHandler {
             });
             await client.query('COMMIT');
             return {
-                file,
-                position: `${line}:${character}`,
-                projects,
                 timeout,
                 ema,
                 order: order_num,
-                children,
                 testId: test_id,
+                meta,
             };
         } catch (e) {
             await client.query('ROLLBACK');

--- a/packages/pg/src/pg-test-run-creator.ts
+++ b/packages/pg/src/pg-test-run-creator.ts
@@ -76,17 +76,7 @@ export class PgTestRunCreator extends BaseTestRunCreator {
                 values: [runId, RunStatus.Created, JSON.stringify(run.config)],
             });
             if (tests.length > 0) {
-                const fields = [
-                    'order_num',
-                    'file',
-                    'line',
-                    'character',
-                    'projects',
-                    'timeout',
-                    'ema',
-                    'children',
-                    'test_id',
-                ];
+                const fields = ['order_num', 'timeout', 'ema', 'test_id', 'meta'];
                 await client.query({
                     text: `INSERT INTO ${this.testsTable} (run_id, ${fields.join(', ')}) VALUES ${tests
                         .map((_, i) => {
@@ -97,19 +87,8 @@ export class PgTestRunCreator extends BaseTestRunCreator {
                         .join(', ')}`,
                     values: [
                         runId,
-                        ...tests.flatMap(({ position, order, file, projects, timeout, ema, children, testId }) => {
-                            const [line, character] = position.split(':');
-                            return [
-                                order,
-                                file,
-                                line,
-                                character,
-                                JSON.stringify(projects),
-                                timeout,
-                                ema,
-                                children != null ? JSON.stringify(children) : null,
-                                testId,
-                            ];
+                        ...tests.flatMap(({ order, timeout, ema, testId, meta }) => {
+                            return [order, timeout, ema, testId, JSON.stringify(meta)];
                         }),
                     ],
                 });

--- a/packages/redis/src/redis-test-run-creator.ts
+++ b/packages/redis/src/redis-test-run-creator.ts
@@ -71,7 +71,7 @@ export class RedisTestRunCreator extends BaseTestRunCreator {
             .set(`${baseTestRunKey}:remainingTime`, remainingTime, setOptions);
         const groupByProject = testRun.config.options.grouping === Grouping.Project;
         for (const test of tests) {
-            const key = `${this._namePrefix}:${TESTS}:${runId}:queue${groupByProject && test.projects.length === 1 ? `:${test.projects[0]}` : ''}`;
+            const key = `${this._namePrefix}:${TESTS}:${runId}:queue${groupByProject && test.meta.projects.length === 1 ? `:${test.meta.projects[0]}` : ''}`;
             pipeline.rPush(key, JSON.stringify(test));
         }
         await pipeline.exec();

--- a/tests/__snapshots__/test-report-project.report.snap
+++ b/tests/__snapshots__/test-report-project.report.snap
@@ -193,6 +193,45 @@
       "averageDuration": 0,
       "duration": 0,
       "fails": 0,
+      "file": "parametrized-case.spec.ts",
+      "lastSuccessfulRunTimestamp": 0,
+      "position": "11:9",
+      "projects": [
+        "chromium"
+      ],
+      "status": 30,
+      "title": "[chromium] parametrized-case.spec.ts > runs first case"
+    },
+    {
+      "averageDuration": 0,
+      "duration": 0,
+      "fails": 0,
+      "file": "parametrized-case.spec.ts",
+      "lastSuccessfulRunTimestamp": 0,
+      "position": "11:9",
+      "projects": [
+        "chromium"
+      ],
+      "status": 20,
+      "title": "[chromium] parametrized-case.spec.ts > runs second case"
+    },
+    {
+      "averageDuration": 0,
+      "duration": 0,
+      "fails": 0,
+      "file": "parametrized-case.spec.ts",
+      "lastSuccessfulRunTimestamp": 0,
+      "position": "11:9",
+      "projects": [
+        "chromium"
+      ],
+      "status": 30,
+      "title": "[chromium] parametrized-case.spec.ts > runs third case"
+    },
+    {
+      "averageDuration": 0,
+      "duration": 0,
+      "fails": 0,
       "file": "serial-top-level.spec.ts",
       "lastSuccessfulRunTimestamp": 0,
       "position": "0:0",
@@ -344,6 +383,45 @@
       ],
       "status": 20,
       "title": "[firefox] failed.spec.ts > should failing for firefox"
+    },
+    {
+      "averageDuration": 0,
+      "duration": 0,
+      "fails": 0,
+      "file": "parametrized-case.spec.ts",
+      "lastSuccessfulRunTimestamp": 0,
+      "position": "11:9",
+      "projects": [
+        "firefox"
+      ],
+      "status": 30,
+      "title": "[firefox] parametrized-case.spec.ts > runs first case"
+    },
+    {
+      "averageDuration": 0,
+      "duration": 0,
+      "fails": 0,
+      "file": "parametrized-case.spec.ts",
+      "lastSuccessfulRunTimestamp": 0,
+      "position": "11:9",
+      "projects": [
+        "firefox"
+      ],
+      "status": 20,
+      "title": "[firefox] parametrized-case.spec.ts > runs second case"
+    },
+    {
+      "averageDuration": 0,
+      "duration": 0,
+      "fails": 0,
+      "file": "parametrized-case.spec.ts",
+      "lastSuccessfulRunTimestamp": 0,
+      "position": "11:9",
+      "projects": [
+        "firefox"
+      ],
+      "status": 30,
+      "title": "[firefox] parametrized-case.spec.ts > runs third case"
     },
     {
       "averageDuration": 0,

--- a/tests/__snapshots__/test-report-test.report.snap
+++ b/tests/__snapshots__/test-report-test.report.snap
@@ -202,6 +202,48 @@
       "averageDuration": 0,
       "duration": 0,
       "fails": 0,
+      "file": "parametrized-case.spec.ts",
+      "lastSuccessfulRunTimestamp": 0,
+      "position": "11:9",
+      "projects": [
+        "chromium",
+        "firefox"
+      ],
+      "status": 30,
+      "title": "parametrized-case.spec.ts > runs first case"
+    },
+    {
+      "averageDuration": 0,
+      "duration": 0,
+      "fails": 0,
+      "file": "parametrized-case.spec.ts",
+      "lastSuccessfulRunTimestamp": 0,
+      "position": "11:9",
+      "projects": [
+        "chromium",
+        "firefox"
+      ],
+      "status": 20,
+      "title": "parametrized-case.spec.ts > runs second case"
+    },
+    {
+      "averageDuration": 0,
+      "duration": 0,
+      "fails": 0,
+      "file": "parametrized-case.spec.ts",
+      "lastSuccessfulRunTimestamp": 0,
+      "position": "11:9",
+      "projects": [
+        "chromium",
+        "firefox"
+      ],
+      "status": 30,
+      "title": "parametrized-case.spec.ts > runs third case"
+    },
+    {
+      "averageDuration": 0,
+      "duration": 0,
+      "fails": 0,
       "file": "serial-top-level.spec.ts",
       "lastSuccessfulRunTimestamp": 0,
       "position": "0:0",

--- a/tests/__snapshots__/test-run-repeat-project.output.snap
+++ b/tests/__snapshots__/test-run-repeat-project.output.snap
@@ -1,3 +1,5 @@
-1  x  [chromium]  failed.spec.ts:4:5  should failing
-2  x  [firefox]   failed.spec.ts:4:5  should failing
-3  x  [firefox]   failed.spec.ts:9:5  should failing for firefox
+1  x  [chromium]  failed.spec.ts:4:5              should failing
+2  x  [firefox]   failed.spec.ts:4:5              should failing
+3  x  [firefox]   failed.spec.ts:9:5              should failing for firefox
+4  x  [chromium]  parametrized-case.spec.ts:11:9  runs second case
+5  x  [firefox]   parametrized-case.spec.ts:11:9  runs second case

--- a/tests/__snapshots__/test-run-repeat-test.output.snap
+++ b/tests/__snapshots__/test-run-repeat-test.output.snap
@@ -1,4 +1,6 @@
-1  x  [chromium]  failed.spec.ts:4:5  should failing
-2  x  [firefox]   failed.spec.ts:4:5  should failing
-3  o  [chromium]  failed.spec.ts:9:5  should failing for firefox
-4  x  [firefox]   failed.spec.ts:9:5  should failing for firefox
+1  x  [chromium]  failed.spec.ts:4:5              should failing
+2  x  [firefox]   failed.spec.ts:4:5              should failing
+3  o  [chromium]  failed.spec.ts:9:5              should failing for firefox
+4  x  [firefox]   failed.spec.ts:9:5              should failing for firefox
+5  x  [chromium]  parametrized-case.spec.ts:11:9  runs second case
+6  x  [firefox]   parametrized-case.spec.ts:11:9  runs second case

--- a/tests/__snapshots__/test-run.output.snap
+++ b/tests/__snapshots__/test-run.output.snap
@@ -14,15 +14,21 @@
 14  x  [firefox]   failed.spec.ts:4:5              should failing
 15  o  [chromium]  failed.spec.ts:9:5              should failing for firefox
 16  x  [firefox]   failed.spec.ts:9:5              should failing for firefox
-17  o  [chromium]  serial-top-level.spec.ts:12:9   inside group
-18  o  [firefox]   serial-top-level.spec.ts:12:9   inside group
-19  o  [chromium]  serial-top-level.spec.ts:6:5    outside of group
-20  o  [firefox]   serial-top-level.spec.ts:6:5    outside of group
-21  o  [chromium]  serial.spec.ts:11:9             inside group
-22  o  [firefox]   serial.spec.ts:11:9             inside group
-23  o  [chromium]  serial.spec.ts:17:13            inside nested group 1
-24  o  [firefox]   serial.spec.ts:17:13            inside nested group 1
-25  o  [chromium]  serial.spec.ts:22:13            inside nested group 2
-26  o  [firefox]   serial.spec.ts:22:13            inside nested group 2
-27  o  [chromium]  serial.spec.ts:5:5              outside of group
-28  o  [firefox]   serial.spec.ts:5:5              outside of group
+17  o  [chromium]  parametrized-case.spec.ts:11:9  runs first case
+18  x  [chromium]  parametrized-case.spec.ts:11:9  runs second case
+19  o  [chromium]  parametrized-case.spec.ts:11:9  runs third case
+20  o  [firefox]   parametrized-case.spec.ts:11:9  runs first case
+21  x  [firefox]   parametrized-case.spec.ts:11:9  runs second case
+22  o  [firefox]   parametrized-case.spec.ts:11:9  runs third case
+23  o  [chromium]  serial-top-level.spec.ts:12:9   inside group
+24  o  [firefox]   serial-top-level.spec.ts:12:9   inside group
+25  o  [chromium]  serial-top-level.spec.ts:6:5    outside of group
+26  o  [firefox]   serial-top-level.spec.ts:6:5    outside of group
+27  o  [chromium]  serial.spec.ts:11:9             inside group
+28  o  [firefox]   serial.spec.ts:11:9             inside group
+29  o  [chromium]  serial.spec.ts:17:13            inside nested group 1
+30  o  [firefox]   serial.spec.ts:17:13            inside nested group 1
+31  o  [chromium]  serial.spec.ts:22:13            inside nested group 2
+32  o  [firefox]   serial.spec.ts:22:13            inside nested group 2
+33  o  [chromium]  serial.spec.ts:5:5              outside of group
+34  o  [firefox]   serial.spec.ts:5:5              outside of group

--- a/tests/test-batch-handlers.test.ts
+++ b/tests/test-batch-handlers.test.ts
@@ -25,12 +25,16 @@ function makeConfig(options: Partial<TestRunConfig['options']> = {}): TestRunCon
 function makeTest(id: string, project = 'chrome', ema = 0): TestItem {
     return {
         testId: id,
-        file: `${id}.spec.ts`,
-        position: '1:1',
-        projects: [project],
         order: 1,
         timeout: 5000,
         ema,
+        meta: {
+            title: id,
+            projects: [project],
+            file: `${id}.spec.ts`,
+            position: '1:1',
+            annotations: [],
+        },
     };
 }
 

--- a/tests/test-ema.test.ts
+++ b/tests/test-ema.test.ts
@@ -20,12 +20,16 @@ class TestableAdapter extends BaseAdapter {
 function makeTestItem(overrides: Partial<TestItem> = {}): TestItem {
     return {
         testId: 'foo.spec.ts > my test',
-        file: 'foo.spec.ts',
-        position: '5:3',
-        projects: ['chrome'],
         order: 1,
         timeout: 5000,
         ema: 0,
+        meta: {
+            title: 'my test',
+            file: 'foo.spec.ts',
+            position: '5:3',
+            projects: ['chrome'],
+            annotations: [],
+        },
         ...overrides,
     };
 }

--- a/tests/test-event-handler.test.ts
+++ b/tests/test-event-handler.test.ts
@@ -22,13 +22,17 @@ function makeConfig(repeatEach = 1): TestRunConfig {
 function makeTestItem(id: string): TestItem {
     return {
         testId: id,
-        file: 'tests/foo.spec.ts',
-        position: '5:1',
-        projects: ['chrome'],
         order: 0,
         timeout: 5000,
         ema: 0,
-    } as unknown as TestItem;
+        meta: {
+            title: id,
+            file: 'tests/foo.spec.ts',
+            position: '5:1',
+            projects: ['chrome'],
+            annotations: [],
+        },
+    };
 }
 
 function makeEvent(

--- a/tests/test-grep-pattern.test.ts
+++ b/tests/test-grep-pattern.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { escapeRegex, makeGrepPattern } from '../packages/core/src/helpers/regex.js';
+
+describe('escapeRegex', () => {
+    it('escapes regex special characters', () => {
+        expect(escapeRegex('a.b*c+d?e^f$g{h}i(j)k|l[m]n\\o')).toBe(
+            'a\\.b\\*c\\+d\\?e\\^f\\$g\\{h\\}i\\(j\\)k\\|l\\[m\\]n\\\\o',
+        );
+    });
+
+    it('leaves plain strings unchanged', () => {
+        expect(escapeRegex('foo bar baz')).toBe('foo bar baz');
+    });
+});
+
+describe('makeGrepPattern', () => {
+    it('builds the expected regex source', () => {
+        expect(makeGrepPattern('foo.spec.ts', 'my test')).toBe(
+            '(?:^| )(?:\\S*/)?foo\\.spec\\.ts (?:.*\\s)?my test(?: @\\S+)*$',
+        );
+    });
+
+    it('escapes special characters in file and title', () => {
+        const pattern = new RegExp(makeGrepPattern('foo (1).spec.ts', 'test [a]'));
+        expect(pattern.test('foo (1).spec.ts > test [a]')).toBe(true);
+        expect(pattern.test('foo (1)Xspec.ts > test [a]')).toBe(false);
+    });
+
+    it('matches file directly followed by title', () => {
+        const pattern = new RegExp(makeGrepPattern('foo.spec.ts', 'my test'));
+        expect(pattern.test('foo.spec.ts my test')).toBe(true);
+    });
+
+    it('matches with a path prefix before the file', () => {
+        const pattern = new RegExp(makeGrepPattern('foo.spec.ts', 'my test'));
+        expect(pattern.test('some/nested/path/foo.spec.ts my test')).toBe(true);
+    });
+
+    it('matches with describe blocks between file and title', () => {
+        const pattern = new RegExp(makeGrepPattern('foo.spec.ts', 'my test'));
+        expect(pattern.test('foo.spec.ts my group my test')).toBe(true);
+    });
+
+    it('matches with trailing tags', () => {
+        const pattern = new RegExp(makeGrepPattern('foo.spec.ts', 'my test'));
+        expect(pattern.test('foo.spec.ts my test @smoke @slow')).toBe(true);
+    });
+
+    it('does not match a different title', () => {
+        const pattern = new RegExp(makeGrepPattern('foo.spec.ts', 'my test'));
+        expect(pattern.test('foo.spec.ts other test')).toBe(false);
+    });
+
+    it('does not match a different file', () => {
+        const pattern = new RegExp(makeGrepPattern('foo.spec.ts', 'my test'));
+        expect(pattern.test('bar.spec.ts my test')).toBe(false);
+    });
+
+    it('does not match when title is only a prefix of the actual title', () => {
+        const pattern = new RegExp(makeGrepPattern('foo.spec.ts', 'my test'));
+        expect(pattern.test('foo.spec.ts my test extra')).toBe(false);
+    });
+});

--- a/tests/test-serial-detection-integration.test.ts
+++ b/tests/test-serial-detection-integration.test.ts
@@ -39,25 +39,27 @@ describe('serial detection integration', () => {
     }, 30_000);
 
     it('groups nested serial suite into a single test item with children', () => {
-        const serialItem = queue.find((t) => t.file === 'serial.spec.ts' && t.children !== undefined);
+        const serialItem = queue.find((t) => t.meta.file === 'serial.spec.ts' && t.meta.children !== undefined);
         expect(serialItem).toBeDefined();
-        expect(serialItem!.children!.length).toBe(2);
+        expect(serialItem!.meta.children!.length).toBe(2);
     });
 
     it('groups file-level serial suite into a single test item with children', () => {
-        const topLevelItem = queue.find((t) => t.file === 'serial-top-level.spec.ts' && t.children !== undefined);
+        const topLevelItem = queue.find(
+            (t) => t.meta.file === 'serial-top-level.spec.ts' && t.meta.children !== undefined,
+        );
         expect(topLevelItem).toBeDefined();
-        expect(topLevelItem!.children!.length).toBe(2);
+        expect(topLevelItem!.meta.children!.length).toBe(2);
     });
 
     it('does not add children to non-serial tests', () => {
-        const basicTests = queue.filter((t) => t.file === 'basic-case.spec.ts');
+        const basicTests = queue.filter((t) => t.meta.file === 'basic-case.spec.ts');
         expect(basicTests.length).toBeGreaterThan(0);
-        expect(basicTests.every((t) => t.children === undefined)).toBe(true);
+        expect(basicTests.every((t) => t.meta.children === undefined)).toBe(true);
     });
 
     it('sums child timeouts for serial suite items', () => {
-        const serialItem = queue.find((t) => t.file === 'serial.spec.ts' && t.children !== undefined);
+        const serialItem = queue.find((t) => t.meta.file === 'serial.spec.ts' && t.meta.children !== undefined);
         expect(serialItem).toBeDefined();
         // two children × 30s default timeout (test.setTimeout is runtime-only, not visible at --list time)
         expect(serialItem!.timeout).toBe(60_000);

--- a/tests/test-sort-pipeline.test.ts
+++ b/tests/test-sort-pipeline.test.ts
@@ -41,15 +41,15 @@ function makeCreator(runInfo: ReporterTestRunInfo): TestableCreator {
 // Helper: single-test run with project grouping.
 // Resulting testId: '[chrome] a.spec.ts > test a'
 const SINGLE_TEST_RUN: ReporterTestRunInfo['testRun'] = {
-    'a.spec.ts': { '1:1': { timeout: 5000, projects: ['chrome'], title: 'test a', annotations: [], children: undefined } },
+    'a.spec.ts': { '1:1': { 'test a': { timeout: 5000, projects: ['chrome'], annotations: [], children: undefined } } },
 };
 
 describe('BaseTestRunCreator sort order', () => {
     it('sorts tests by EMA descending (highest ema = order 1)', async () => {
         const runInfo = makeRunInfo({
-            'a.spec.ts': { '1:1': { timeout: 5000, projects: ['chrome'], title: 'test a', annotations: [], children: undefined } },
-            'b.spec.ts': { '1:1': { timeout: 5000, projects: ['chrome'], title: 'test b', annotations: [], children: undefined } },
-            'c.spec.ts': { '1:1': { timeout: 5000, projects: ['chrome'], title: 'test c', annotations: [], children: undefined } },
+            'a.spec.ts': { '1:1': { 'test a': { timeout: 5000, projects: ['chrome'], annotations: [], children: undefined } } },
+            'b.spec.ts': { '1:1': { 'test b': { timeout: 5000, projects: ['chrome'], annotations: [], children: undefined } } },
+            'c.spec.ts': { '1:1': { 'test c': { timeout: 5000, projects: ['chrome'], annotations: [], children: undefined } } },
         });
         const creator = makeCreator(runInfo);
         creator.testInfoMap.set('[chrome] a.spec.ts > test a', { ema: 100, fails: 0 });
@@ -65,8 +65,8 @@ describe('BaseTestRunCreator sort order', () => {
 
     it('failure adjustment boosts sort value: ema=100, fails=5, window=10 → adjusted=150 > ema=130', async () => {
         const runInfo = makeRunInfo({
-            'a.spec.ts': { '1:1': { timeout: 5000, projects: ['chrome'], title: 'test a', annotations: [], children: undefined } },
-            'b.spec.ts': { '1:1': { timeout: 5000, projects: ['chrome'], title: 'test b', annotations: [], children: undefined } },
+            'a.spec.ts': { '1:1': { 'test a': { timeout: 5000, projects: ['chrome'], annotations: [], children: undefined } } },
+            'b.spec.ts': { '1:1': { 'test b': { timeout: 5000, projects: ['chrome'], annotations: [], children: undefined } } },
         });
         const creator = makeCreator(runInfo);
         // A: ema=100, fails=5, window=10 → adjusted = 100 * (5/10 + 1) = 150
@@ -81,8 +81,8 @@ describe('BaseTestRunCreator sort order', () => {
 
     it('new test (no history) uses timeout as sort value', async () => {
         const runInfo = makeRunInfo({
-            'a.spec.ts': { '1:1': { timeout: 5000, projects: ['chrome'], title: 'new', annotations: [], children: undefined } },
-            'b.spec.ts': { '1:1': { timeout: 3000, projects: ['chrome'], title: 'known', annotations: [], children: undefined } },
+            'a.spec.ts': { '1:1': { 'new': { timeout: 5000, projects: ['chrome'], annotations: [], children: undefined } } },
+            'b.spec.ts': { '1:1': { 'known': { timeout: 3000, projects: ['chrome'], annotations: [], children: undefined } } },
         });
         const creator = makeCreator(runInfo);
         // a has no history — uses timeout=5000
@@ -95,8 +95,8 @@ describe('BaseTestRunCreator sort order', () => {
 
     it('order field is 1-indexed and ascending in result array', async () => {
         const runInfo = makeRunInfo({
-            'a.spec.ts': { '1:1': { timeout: 5000, projects: ['chrome'], title: 'test', annotations: [], children: undefined } },
-            'b.spec.ts': { '1:1': { timeout: 5000, projects: ['chrome'], title: 'test', annotations: [], children: undefined } },
+            'a.spec.ts': { '1:1': { 'test': { timeout: 5000, projects: ['chrome'], annotations: [], children: undefined } } },
+            'b.spec.ts': { '1:1': { 'test': { timeout: 5000, projects: ['chrome'], annotations: [], children: undefined } } },
         });
         const creator = makeCreator(runInfo);
         creator.testInfoMap.set('[chrome] a.spec.ts > test', { ema: 200, fails: 0 });
@@ -113,8 +113,8 @@ describe('BaseTestRunCreator duplicate ID validation', () => {
     it('throws when two tests produce the same testId', async () => {
         const ID_TYPE = '@playwright-orchestrator/id';
         const runInfo = makeRunInfo({
-            'a.spec.ts': { '1:1': { timeout: 5000, projects: ['chrome'], title: 'test', annotations: [{ type: ID_TYPE, description: 'dup' }], children: undefined } },
-            'b.spec.ts': { '2:1': { timeout: 5000, projects: ['chrome'], title: 'test', annotations: [{ type: ID_TYPE, description: 'dup' }], children: undefined } },
+            'a.spec.ts': { '1:1': { 'test': { timeout: 5000, projects: ['chrome'], annotations: [{ type: ID_TYPE, description: 'dup' }], children: undefined } } },
+            'b.spec.ts': { '2:1': { 'test': { timeout: 5000, projects: ['chrome'], annotations: [{ type: ID_TYPE, description: 'dup' }], children: undefined } } },
         });
         const creator = makeCreator(runInfo);
 
@@ -128,11 +128,12 @@ describe('BaseTestRunCreator grouping modes', () => {
     const RUN: ReporterTestRunInfo['testRun'] = {
         'a.spec.ts': {
             '1:1': {
-                timeout: 5000,
-                projects: ['chrome', 'firefox'],
-                title: 'test a',
-                annotations: [],
-                children: undefined,
+                'test a': {
+                    timeout: 5000,
+                    projects: ['chrome', 'firefox'],
+                    annotations: [],
+                    children: undefined,
+                },
             },
         },
     };
@@ -142,7 +143,7 @@ describe('BaseTestRunCreator grouping modes', () => {
         await creator.create({ runId: 'r', args: [], options: makeOptions({ grouping: Grouping.Test }) });
 
         expect(creator.savedTests).toHaveLength(1);
-        expect(creator.savedTests[0].projects).toEqual(['chrome', 'firefox']);
+        expect(creator.savedTests[0].meta.projects).toEqual(['chrome', 'firefox']);
         expect(creator.savedTests[0].testId).toBe('a.spec.ts > test a'); // no project prefix
     });
 
@@ -166,9 +167,9 @@ describe('BaseTestRunCreator infrastructure project filtering', () => {
     it('filters out tests from dependency/teardown projects', async () => {
         const runInfo = makeRunInfo(
             {
-                'setup.spec.ts': { '1:1': { timeout: 5000, projects: ['setup'], title: 'setup', annotations: [], children: undefined } },
-                'teardown.spec.ts': { '1:1': { timeout: 5000, projects: ['teardown'], title: 'teardown', annotations: [], children: undefined } },
-                'a.spec.ts': { '1:1': { timeout: 5000, projects: ['chromium'], title: 'test a', annotations: [], children: undefined } },
+                'setup.spec.ts': { '1:1': { 'setup': { timeout: 5000, projects: ['setup'], annotations: [], children: undefined } } },
+                'teardown.spec.ts': { '1:1': { 'teardown': { timeout: 5000, projects: ['teardown'], annotations: [], children: undefined } } },
+                'a.spec.ts': { '1:1': { 'test a': { timeout: 5000, projects: ['chromium'], annotations: [], children: undefined } } },
             },
             projects,
         );
@@ -182,7 +183,7 @@ describe('BaseTestRunCreator infrastructure project filtering', () => {
     it('strips infrastructure projects from mixed-project tests', async () => {
         const runInfo = makeRunInfo(
             {
-                'a.spec.ts': { '1:1': { timeout: 5000, projects: ['setup', 'chromium'], title: 'test a', annotations: [], children: undefined } },
+                'a.spec.ts': { '1:1': { 'test a': { timeout: 5000, projects: ['setup', 'chromium'], annotations: [], children: undefined } } },
             },
             projects,
         );
@@ -190,7 +191,7 @@ describe('BaseTestRunCreator infrastructure project filtering', () => {
         await creator.create({ runId: 'r', args: [], options: makeOptions() });
 
         expect(creator.savedTests).toHaveLength(1);
-        expect(creator.savedTests[0].projects).toEqual(['chromium']);
+        expect(creator.savedTests[0].meta.projects).toEqual(['chromium']);
     });
 
     it('keeps all tests when no dependencies are configured', async () => {
@@ -199,7 +200,7 @@ describe('BaseTestRunCreator infrastructure project filtering', () => {
         ];
         const runInfo = makeRunInfo(
             {
-                'a.spec.ts': { '1:1': { timeout: 5000, projects: ['chromium'], title: 'test a', annotations: [], children: undefined } },
+                'a.spec.ts': { '1:1': { 'test a': { timeout: 5000, projects: ['chromium'], annotations: [], children: undefined } } },
             },
             noDeps,
         );

--- a/tests/utils/test-consistent-reporter.ts
+++ b/tests/utils/test-consistent-reporter.ts
@@ -41,7 +41,9 @@ export default class ConsistentTestReporter implements Reporter {
         const tests = Object.values(this.tests).sort((a, b) => {
             const cmp = a.location.localeCompare(b.location);
             if (cmp !== 0) return cmp;
-            return a.project.localeCompare(b.project);
+            const cmpProject = a.project.localeCompare(b.project);
+            if (cmpProject !== 0) return cmpProject;
+            return a.title.localeCompare(b.title);
         });
         const padStartLen = tests.length.toString().length;
         for (let i = 0; i < tests.length; i++) {


### PR DESCRIPTION
Playwright parameterised tests are not uniquely identified by file + location, because multiple generated cases can share the same source position while representing distinct test variants. This change updates the run flow to select tests by grep-based matching against their generated names, enabling correct execution of parameterised tests.

This also includes related cleanup and refactoring across storage adapters and test metadata handling, but those changes are secondary to the functional requirement of supporting parameterised tests.